### PR TITLE
feat: デスクトップ・モバイル全機能実装 + エラーハンドリング

### DIFF
--- a/packages/desktop/src/main/__tests__/pty-server.test.ts
+++ b/packages/desktop/src/main/__tests__/pty-server.test.ts
@@ -156,6 +156,20 @@ describe('startPtyServer', () => {
       sendMessage(ws, { type: 'ping' })
       expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'pong' }))
     })
+
+    it('pong メッセージを受信してもエラーにならない', () => {
+      const { ws } = connectAndAuth()
+      expect(() => sendMessage(ws, { type: 'pong' })).not.toThrow()
+    })
+
+    it('不正な JSON メッセージを受信してもエラーにならない', () => {
+      startPtyServer()
+      const ws = createMockWs()
+      wssState.instance!.emit('connection', ws)
+      sendMessage(ws, { type: 'auth', token: 'test-token' })
+      ws.send.mockClear()
+      expect(() => ws.emit('message', Buffer.from('not-valid-json'))).not.toThrow()
+    })
   })
 
   describe('PTY イベント', () => {
@@ -181,11 +195,11 @@ describe('startPtyServer', () => {
       expect(ws.send).not.toHaveBeenCalled()
     })
 
-    it('shell の onExit → 終了メッセージ送信 + ws.close() を呼ぶ', () => {
+    it('shell の onExit → shell_exit メッセージ送信 + ws.close() を呼ぶ', () => {
       const { ws } = connectAndAuth()
       ptyState.lastShell._onExitCb({ exitCode: 0 })
       expect(ws.send).toHaveBeenCalledWith(
-        JSON.stringify({ type: 'output', data: '\r\n[claudeが終了しました (exit code: 0)]' }),
+        JSON.stringify({ type: 'shell_exit', exitCode: 0 }),
       )
       expect(ws.close).toHaveBeenCalled()
     })

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -6,6 +6,13 @@ import { v4 as uuidv4 } from 'uuid'
 
 const AUTH_TOKEN = process.env.REMOTE_TOKEN ?? uuidv4()
 
+// サーバーからクライアントへのping間隔（ms）
+const SERVER_PING_INTERVAL = 30000
+// pong未応答タイムアウト（ms）: ping送信後この時間内にpongがなければ切断
+const PONG_TIMEOUT = 10000
+// アイドル判定時間（ms）: 最後の入力からこの時間経過でidleに変更
+const IDLE_TIMEOUT = 300000
+
 export function startPtyServer(
   port = DEFAULT_WS_PORT,
   onSessionsChange?: (sessions: SessionInfo[]) => void,
@@ -24,13 +31,62 @@ export function startPtyServer(
     let authenticated = false
     let shell: pty.IPty | null = null
     let sessionId: string | null = null
+    let pongPending = false
+    let pingIntervalId: ReturnType<typeof setInterval> | null = null
+    let pongTimeoutId: ReturnType<typeof setTimeout> | null = null
+    let idleTimeoutId: ReturnType<typeof setTimeout> | null = null
 
     const authTimeout = setTimeout(() => {
       if (!authenticated) ws.close()
     }, 5000)
 
+    const setActive = () => {
+      if (!sessionId) return
+      const session = sessions.get(sessionId)
+      if (session && session.status !== 'active') {
+        sessions.set(sessionId, { ...session, status: 'active' })
+        notify()
+      }
+      if (idleTimeoutId) clearTimeout(idleTimeoutId)
+      idleTimeoutId = setTimeout(() => {
+        if (!sessionId) return
+        const s = sessions.get(sessionId)
+        if (s) {
+          sessions.set(sessionId, { ...s, status: 'idle' })
+          notify()
+        }
+      }, IDLE_TIMEOUT)
+    }
+
+    const startPingInterval = () => {
+      pingIntervalId = setInterval(() => {
+        if (ws.readyState !== ws.OPEN) return
+        pongPending = true
+        ws.send(JSON.stringify({ type: 'ping' }))
+        pongTimeoutId = setTimeout(() => {
+          if (pongPending) {
+            console.log(`Session ${sessionId}: pong timeout, closing connection`)
+            ws.close()
+          }
+        }, PONG_TIMEOUT)
+      }, SERVER_PING_INTERVAL)
+    }
+
+    const cleanup = () => {
+      clearTimeout(authTimeout)
+      if (pingIntervalId) clearInterval(pingIntervalId)
+      if (pongTimeoutId) clearTimeout(pongTimeoutId)
+      if (idleTimeoutId) clearTimeout(idleTimeoutId)
+    }
+
     ws.on('message', (raw) => {
-      const msg: WsMessage = JSON.parse(raw.toString())
+      let msg: WsMessage
+      try {
+        msg = JSON.parse(raw.toString())
+      } catch {
+        console.warn('Received malformed message, ignoring')
+        return
+      }
 
       if (!authenticated) {
         if (msg.type === 'auth' && msg.token === AUTH_TOKEN) {
@@ -46,6 +102,15 @@ export function startPtyServer(
             clientIP: req?.socket?.remoteAddress,
           })
           notify()
+          startPingInterval()
+          idleTimeoutId = setTimeout(() => {
+            if (!sessionId) return
+            const s = sessions.get(sessionId)
+            if (s) {
+              sessions.set(sessionId, { ...s, status: 'idle' })
+              notify()
+            }
+          }, IDLE_TIMEOUT)
 
           ws.send(JSON.stringify({ type: 'auth_ok' }))
         } else {
@@ -57,13 +122,23 @@ export function startPtyServer(
 
       if (!shell) return
 
-      if (msg.type === 'input') shell.write(msg.data)
+      if (msg.type === 'input') {
+        shell.write(msg.data)
+        setActive()
+      }
       if (msg.type === 'resize') shell.resize(msg.cols, msg.rows)
       if (msg.type === 'ping') ws.send(JSON.stringify({ type: 'pong' }))
+      if (msg.type === 'pong') {
+        pongPending = false
+        if (pongTimeoutId) {
+          clearTimeout(pongTimeoutId)
+          pongTimeoutId = null
+        }
+      }
     })
 
     ws.on('close', () => {
-      clearTimeout(authTimeout)
+      cleanup()
       shell?.kill()
       if (sessionId) {
         sessions.delete(sessionId)
@@ -92,11 +167,7 @@ function spawnClaude(ws: WebSocket): pty.IPty {
 
   shell.onExit(({ exitCode }) => {
     if (ws.readyState === ws.OPEN) {
-      const msg: WsMessage = {
-        type: 'output',
-        data: `\r\n[claudeが終了しました (exit code: ${exitCode})]`,
-      }
-      ws.send(JSON.stringify(msg))
+      ws.send(JSON.stringify({ type: 'shell_exit', exitCode } satisfies WsMessage))
       ws.close()
     }
   })

--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -23,7 +23,7 @@ export default function App() {
       <TerminalScreen
         ip={connection.ip}
         token={connection.token}
-        onAuthError={handleDisconnect}
+        onDisconnect={handleDisconnect}
       />
     )
   }

--- a/packages/mobile/src/__tests__/terminal.html.test.ts
+++ b/packages/mobile/src/__tests__/terminal.html.test.ts
@@ -38,4 +38,17 @@ describe('buildTerminalHtml', () => {
     expect(html).toContain('ReactNativeWebView')
     expect(html).toContain('postMessage')
   })
+
+  it('接続タイムアウト (CONNECT_TIMEOUT) の記述が含まれる', () => {
+    expect(html).toContain('CONNECT_TIMEOUT')
+    expect(html).toContain('10000')
+  })
+
+  it('shell_exit メッセージのハンドラが含まれる', () => {
+    expect(html).toContain("shell_exit")
+  })
+
+  it('noReconnect フラグの記述が含まれる', () => {
+    expect(html).toContain('noReconnect')
+  })
 })

--- a/packages/mobile/src/assets/terminal.html.ts
+++ b/packages/mobile/src/assets/terminal.html.ts
@@ -31,37 +31,77 @@ export function buildTerminalHtml(wsUrl: string, token: string): string {
     let ws = null
     let reconnectDelay = 1000
     const MAX_RECONNECT_DELAY = 30000
+    // 接続試行タイムアウト（ms）: CONNECTINGのまま無応答の場合に切断して再試行
+    const CONNECT_TIMEOUT = 10000
+    let reconnectAttempt = 0
+    let connectTimeoutId = null
+    let reconnectTimerId = null
+    // 認証エラー・シェル終了後は自動再接続しない
+    let noReconnect = false
+
+    function postToNative(data) {
+      window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify(data))
+    }
 
     function connect() {
+      if (noReconnect) return
+
+      reconnectAttempt++
       ws = new WebSocket('${wsUrl}')
 
+      // 接続タイムアウト: CONNECTINGのまま応答がない場合
+      connectTimeoutId = setTimeout(() => {
+        if (ws && ws.readyState === WebSocket.CONNECTING) {
+          term.write('\\r\\n[接続タイムアウト。再接続中...]\\r\\n')
+          ws.close()
+        }
+      }, CONNECT_TIMEOUT)
+
       ws.onopen = () => {
+        clearTimeout(connectTimeoutId)
         reconnectDelay = 1000
+        reconnectAttempt = 0
         ws.send(JSON.stringify({ type: 'auth', token: '${token}' }))
+        postToNative({ type: 'connected' })
       }
 
       ws.onmessage = (e) => {
-        const msg = JSON.parse(e.data)
-        if (msg.type === 'output') term.write(msg.data)
-        if (msg.type === 'auth_ok') {
-          // 認証成功後にサイズを送信
+        let msg
+        try {
+          msg = JSON.parse(e.data)
+        } catch {
+          return
+        }
+
+        if (msg.type === 'output') {
+          term.write(msg.data)
+        } else if (msg.type === 'auth_ok') {
           ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }))
-        }
-        if (msg.type === 'auth_error') {
+          postToNative({ type: 'auth_ok' })
+        } else if (msg.type === 'auth_error') {
           term.write('\\r\\n[認証エラー: ' + msg.reason + ']\\r\\n')
+          noReconnect = true
           ws.close()
-          // 認証エラー時は再接続しない
-          window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'auth_error', reason: msg.reason }))
+          postToNative({ type: 'auth_error', reason: msg.reason })
+        } else if (msg.type === 'shell_exit') {
+          term.write('\\r\\n[セッションが終了しました (exit code: ' + msg.exitCode + ')]\\r\\n')
+          noReconnect = true
+          postToNative({ type: 'shell_exit', exitCode: msg.exitCode })
+        } else if (msg.type === 'ping') {
+          ws.send(JSON.stringify({ type: 'pong' }))
         }
-        if (msg.type === 'pong') {
-          // keepalive確認
-        }
+        // pong: keepalive確認、処理不要
       }
 
       ws.onclose = () => {
-        term.write('\\r\\n[接続が切断されました。再接続中... (' + (reconnectDelay / 1000) + 's)]\\r\\n')
-        window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'disconnected' }))
-        setTimeout(() => {
+        clearTimeout(connectTimeoutId)
+        if (noReconnect) return
+
+        const delaySec = reconnectDelay / 1000
+        term.write('\\r\\n[切断されました。' + delaySec + '秒後に再接続します... (試行: ' + reconnectAttempt + ')]\\r\\n')
+        postToNative({ type: 'disconnected', reconnectDelay })
+
+        reconnectTimerId = setTimeout(() => {
           reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
           connect()
         }, reconnectDelay)
@@ -87,6 +127,7 @@ export function buildTerminalHtml(wsUrl: string, token: string): string {
       }
     })
 
+    // クライアント側keepalive: サーバーからのpingに加え、クライアントからも定期送信
     setInterval(() => {
       if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: 'ping' }))

--- a/packages/mobile/src/screens/TerminalScreen.tsx
+++ b/packages/mobile/src/screens/TerminalScreen.tsx
@@ -1,18 +1,32 @@
-import React, { useRef, useCallback } from 'react'
+import React, { useRef, useCallback, useState } from 'react'
 import { View, StyleSheet, TouchableOpacity, Text } from 'react-native'
 import { WebView, WebViewMessageEvent } from 'react-native-webview'
 import { DEFAULT_WS_PORT } from '@remocoder/shared'
 import { buildTerminalHtml } from '../assets/terminal.html'
 
+type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'auth_error' | 'shell_exit'
+
 interface Props {
   ip: string
   token: string
-  onAuthError: () => void
+  onDisconnect: () => void
 }
 
-export function TerminalScreen({ ip, token, onAuthError }: Props) {
+const STATUS_CONFIG: Record<
+  ConnectionStatus,
+  { label: string; color: string; bgColor: string }
+> = {
+  connecting: { label: '接続中...', color: '#d4d4d4', bgColor: 'rgba(100,100,100,0.8)' },
+  connected: { label: '接続済み', color: '#4ec9b0', bgColor: 'rgba(0,80,60,0.8)' },
+  reconnecting: { label: '再接続中...', color: '#dcdcaa', bgColor: 'rgba(80,70,0,0.8)' },
+  auth_error: { label: '認証エラー', color: '#f44747', bgColor: 'rgba(80,0,0,0.8)' },
+  shell_exit: { label: 'セッション終了', color: '#d4d4d4', bgColor: 'rgba(50,50,50,0.8)' },
+}
+
+export function TerminalScreen({ ip, token, onDisconnect }: Props) {
   const wsUrl = `ws://${ip}:${DEFAULT_WS_PORT}`
-  const html = buildTerminalHtml(wsUrl, token)
+  const [status, setStatus] = useState<ConnectionStatus>('connecting')
+  const [webViewKey, setWebViewKey] = useState(0)
   const webViewRef = useRef<WebView>(null)
 
   const handleMessage = useCallback(
@@ -20,18 +34,37 @@ export function TerminalScreen({ ip, token, onAuthError }: Props) {
       try {
         const msg = JSON.parse(event.nativeEvent.data)
         if (msg.type === 'auth_error') {
-          onAuthError()
+          setStatus('auth_error')
+        } else if (msg.type === 'auth_ok') {
+          setStatus('connected')
+        } else if (msg.type === 'connected') {
+          setStatus('connected')
+        } else if (msg.type === 'disconnected') {
+          setStatus('reconnecting')
+        } else if (msg.type === 'shell_exit') {
+          setStatus('shell_exit')
         }
       } catch {
         // 無視
       }
     },
-    [onAuthError],
+    [],
   )
+
+  const handleRetry = useCallback(() => {
+    setStatus('connecting')
+    // WebViewを再マウントして接続をリセット
+    setWebViewKey((k) => k + 1)
+  }, [])
+
+  const html = buildTerminalHtml(wsUrl, token)
+  const statusCfg = STATUS_CONFIG[status]
+  const showRetry = status === 'auth_error' || status === 'shell_exit'
 
   return (
     <View style={styles.container}>
       <WebView
+        key={webViewKey}
         ref={webViewRef}
         source={{ html }}
         style={styles.webview}
@@ -41,9 +74,20 @@ export function TerminalScreen({ ip, token, onAuthError }: Props) {
         onMessage={handleMessage}
         allowFileAccess={false}
       />
-      <TouchableOpacity style={styles.disconnectButton} onPress={onAuthError}>
-        <Text style={styles.disconnectText}>切断</Text>
-      </TouchableOpacity>
+      {/* ステータスバー */}
+      <View style={[styles.statusBar, { backgroundColor: statusCfg.bgColor }]}>
+        <Text style={[styles.statusText, { color: statusCfg.color }]}>{statusCfg.label}</Text>
+        <View style={styles.statusActions}>
+          {showRetry && (
+            <TouchableOpacity style={styles.actionButton} onPress={handleRetry}>
+              <Text style={styles.actionButtonText}>再試行</Text>
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity style={styles.actionButton} onPress={onDisconnect}>
+            <Text style={styles.actionButtonText}>切断</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
     </View>
   )
 }
@@ -51,17 +95,33 @@ export function TerminalScreen({ ip, token, onAuthError }: Props) {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#1e1e1e' },
   webview: { flex: 1 },
-  disconnectButton: {
+  statusBar: {
     position: 'absolute',
-    top: 16,
-    right: 16,
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    top: 0,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     paddingHorizontal: 12,
     paddingVertical: 6,
-    borderRadius: 6,
   },
-  disconnectText: {
+  statusText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  statusActions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  actionButton: {
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 4,
+  },
+  actionButtonText: {
     color: '#d4d4d4',
-    fontSize: 13,
+    fontSize: 12,
   },
 })

--- a/packages/mobile/src/screens/__tests__/TerminalScreen.test.tsx
+++ b/packages/mobile/src/screens/__tests__/TerminalScreen.test.tsx
@@ -4,8 +4,8 @@ import { TerminalScreen } from '../TerminalScreen'
 import { WebView } from '../../__mocks__/react-native-webview'
 
 describe('TerminalScreen', () => {
-  const onAuthError = jest.fn()
-  const defaultProps = { ip: '100.64.0.1', token: 'test-token', onAuthError }
+  const onDisconnect = jest.fn()
+  const defaultProps = { ip: '100.64.0.1', token: 'test-token', onDisconnect }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -16,18 +16,23 @@ describe('TerminalScreen', () => {
     expect(screen.getByTestId('webview')).toBeTruthy()
   })
 
-  it('WebView から auth_error メッセージ → onAuthError が呼ばれる', () => {
+  it('初期状態で「接続中...」ステータスが表示される', () => {
+    render(<TerminalScreen {...defaultProps} />)
+    expect(screen.getByText('接続中...')).toBeTruthy()
+  })
+
+  it('auth_ok メッセージ → 「接続済み」ステータスに変わる', () => {
     render(<TerminalScreen {...defaultProps} />)
     const webViewEl = screen.UNSAFE_getByType(WebView)
     act(() => {
       webViewEl.props.onMessage({
-        nativeEvent: { data: JSON.stringify({ type: 'auth_error', reason: 'invalid token' }) },
+        nativeEvent: { data: JSON.stringify({ type: 'auth_ok' }) },
       })
     })
-    expect(onAuthError).toHaveBeenCalled()
+    expect(screen.getByText('接続済み')).toBeTruthy()
   })
 
-  it('auth_error 以外のメッセージでは onAuthError を呼ばない', () => {
+  it('disconnected メッセージ → 「再接続中...」ステータスに変わる', () => {
     render(<TerminalScreen {...defaultProps} />)
     const webViewEl = screen.UNSAFE_getByType(WebView)
     act(() => {
@@ -35,7 +40,33 @@ describe('TerminalScreen', () => {
         nativeEvent: { data: JSON.stringify({ type: 'disconnected' }) },
       })
     })
-    expect(onAuthError).not.toHaveBeenCalled()
+    expect(screen.getByText('再接続中...')).toBeTruthy()
+  })
+
+  it('auth_error メッセージ → 「認証エラー」ステータスと「再試行」ボタンが表示される', () => {
+    render(<TerminalScreen {...defaultProps} />)
+    const webViewEl = screen.UNSAFE_getByType(WebView)
+    act(() => {
+      webViewEl.props.onMessage({
+        nativeEvent: { data: JSON.stringify({ type: 'auth_error', reason: 'invalid token' }) },
+      })
+    })
+    expect(screen.getByText('認証エラー')).toBeTruthy()
+    expect(screen.getByText('再試行')).toBeTruthy()
+    // auth_error だけでは onDisconnect を呼ばない
+    expect(onDisconnect).not.toHaveBeenCalled()
+  })
+
+  it('shell_exit メッセージ → 「セッション終了」ステータスと「再試行」ボタンが表示される', () => {
+    render(<TerminalScreen {...defaultProps} />)
+    const webViewEl = screen.UNSAFE_getByType(WebView)
+    act(() => {
+      webViewEl.props.onMessage({
+        nativeEvent: { data: JSON.stringify({ type: 'shell_exit', exitCode: 0 }) },
+      })
+    })
+    expect(screen.getByText('セッション終了')).toBeTruthy()
+    expect(screen.getByText('再試行')).toBeTruthy()
   })
 
   it('不正な JSON でも throw しない', () => {
@@ -48,9 +79,22 @@ describe('TerminalScreen', () => {
     }).not.toThrow()
   })
 
-  it('切断ボタン押下で onAuthError が呼ばれる', () => {
+  it('切断ボタン押下で onDisconnect が呼ばれる', () => {
     render(<TerminalScreen {...defaultProps} />)
     fireEvent.press(screen.getByText('切断'))
-    expect(onAuthError).toHaveBeenCalled()
+    expect(onDisconnect).toHaveBeenCalled()
+  })
+
+  it('再試行ボタン押下で ステータスが「接続中...」に戻る', () => {
+    render(<TerminalScreen {...defaultProps} />)
+    const webViewEl = screen.UNSAFE_getByType(WebView)
+    act(() => {
+      webViewEl.props.onMessage({
+        nativeEvent: { data: JSON.stringify({ type: 'auth_error', reason: 'invalid token' }) },
+      })
+    })
+    fireEvent.press(screen.getByText('再試行'))
+    expect(screen.getByText('接続中...')).toBeTruthy()
+    expect(onDisconnect).not.toHaveBeenCalled()
   })
 })

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -8,6 +8,7 @@ export type WsMessage =
   | { type: 'auth'; token: string }
   | { type: 'auth_ok' }
   | { type: 'auth_error'; reason: string }
+  | { type: 'shell_exit'; exitCode: number }
 
 export interface SessionInfo {
   id: string


### PR DESCRIPTION
## Summary

- **Issue #2**: PTYサーバー実装 (`pty-server.ts`) — WebSocketサーバー、node-pty連携、トークン認証
- **Issue #3**: Tailscale IP自動取得 (`tailscale.ts`)
- **Issue #4**: Electronメインプロセス更新 (`index.ts`) — システムトレイ、IPC、セッション管理
- **Issue #5**: MobileアプリのConnectScreen実装 — AsyncStorageによる接続情報保存
- **Issue #6**: MobileアプリのTerminalScreen実装 — WebView + xterm.js
- **Issue #7**: MobileアプリのApp.tsx実装 — 画面遷移管理
- **Issue #8**: エラーハンドリング・再接続ロジック
  - サーバー側: ping/pongタイムアウトによるデッド接続検知、セッションidle追跡、不正JSONハンドリング
  - クライアント側: 接続タイムアウト検知、`shell_exit`メッセージ対応、`noReconnect`フラグ
  - TerminalScreen: 接続ステータスバー（色分け表示）、認証エラー/セッション終了時の再試行ボタン

## Test plan

- [x] デスクトップ: `pnpm --filter @remocoder/desktop test` が全テスト通過
- [x] モバイル: `pnpm --filter @remocoder/mobile test` が全テスト通過
- [x] 共有: `pnpm --filter @remocoder/shared test` が全テスト通過
- [x] CI が全ジョブ通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)