### PR TITLE
fix: EAS CLIの警告に対応するための設定を追加

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -12,7 +12,8 @@
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true,
           "NSAllowsArbitraryLoadsInWebContent": true
-        }
+        },
+        "ITSAppUsesNonExemptEncryption": false
       }
     },
     "android": {

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 10.0.0"
+    "version": ">= 10.0.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {


### PR DESCRIPTION
- eas.json: appVersionSource を remote に設定
- app.json: ITSAppUsesNonExemptEncryption を false に設定