### PR TITLE
test: power-manager・CLI・mobile utils のテストを追加

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "node --loader ts-node/esm src/index.ts"
+    "dev": "node --loader ts-node/esm src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@remocoder/shared": "workspace:*",
@@ -19,6 +21,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/ws": "^8.18.1",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -1,0 +1,301 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── Hoisted mock state ────────────────────────────────────────────────────────
+const wsState = vi.hoisted(() => ({ instance: null as any }))
+const mockWsSend = vi.hoisted(() => vi.fn())
+const mockWsClose = vi.hoisted(() => vi.fn())
+const mockPtyShell = vi.hoisted(() => ({ instance: null as any }))
+const mockPtySpawn = vi.hoisted(() => vi.fn())
+const mockReadFileSync = vi.hoisted(() => vi.fn())
+
+vi.mock('ws', async () => {
+  const { EventEmitter } = await import('events')
+
+  class MockWebSocket extends EventEmitter {
+    static OPEN = 1
+    readyState = 1
+    send = mockWsSend
+    close = mockWsClose
+    constructor(_url: string) {
+      super()
+      wsState.instance = this
+    }
+  }
+
+  return { default: MockWebSocket }
+})
+
+vi.mock('node-pty', () => ({
+  spawn: mockPtySpawn,
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockReadFileSync,
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createMockShell() {
+  const shell: any = {
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    _onDataCb: null as ((data: string) => void) | null,
+    _onExitCb: null as ((e: { exitCode: number }) => void) | null,
+    onData(cb: (data: string) => void) {
+      this._onDataCb = cb
+    },
+    onExit(cb: (e: { exitCode: number }) => void) {
+      this._onExitCb = cb
+    },
+  }
+  mockPtyShell.instance = shell
+  return shell
+}
+
+function sendWsMessage(msg: object) {
+  wsState.instance.emit('message', Buffer.from(JSON.stringify(msg)))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('CLI index', () => {
+  const savedEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...savedEnv }
+    process.env.REMOCODER_TOKEN = 'test-token'
+    delete process.env.REMOCODER_HOST
+    mockWsSend.mockClear()
+    mockWsClose.mockClear()
+    mockPtySpawn.mockClear()
+    mockPtySpawn.mockImplementation(createMockShell)
+    wsState.instance = null
+    mockPtyShell.instance = null
+  })
+
+  afterEach(() => {
+    process.env = savedEnv
+  })
+
+  // ── 接続・認証 ──────────────────────────────────────────────────────────────
+
+  describe('接続・認証', () => {
+    it('open イベントで auth メッセージを送信する', async () => {
+      await import('../index')
+      wsState.instance.emit('open')
+      expect(mockWsSend).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'auth', token: 'test-token' }),
+      )
+    })
+
+    it('auth_ok → session_register を送信する', async () => {
+      await import('../index')
+      wsState.instance.emit('open')
+      sendWsMessage({ type: 'auth_ok' })
+      expect(mockWsSend).toHaveBeenCalledWith(
+        expect.stringContaining('"session_register"'),
+      )
+    })
+
+    it('session_register に cols / rows を含む', async () => {
+      await import('../index')
+      wsState.instance.emit('open')
+      sendWsMessage({ type: 'auth_ok' })
+      const call = mockWsSend.mock.calls.find((c: string[]) =>
+        c[0].includes('session_register'),
+      )
+      const msg = JSON.parse(call![0])
+      expect(typeof msg.cols).toBe('number')
+      expect(typeof msg.rows).toBe('number')
+    })
+
+    it('auth_error → process.exit(1) を呼ぶ', async () => {
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {
+          throw new Error('process.exit called')
+        }) as any)
+      try {
+        await import('../index')
+        wsState.instance.emit('open')
+        expect(() =>
+          sendWsMessage({ type: 'auth_error', reason: 'invalid token' }),
+        ).toThrow('process.exit called')
+        expect(mockExit).toHaveBeenCalledWith(1)
+      } finally {
+        mockExit.mockRestore()
+      }
+    })
+  })
+
+  // ── セッション登録 ──────────────────────────────────────────────────────────
+
+  describe('session_registered', () => {
+    it('claude PTY を起動する', async () => {
+      await import('../index')
+      wsState.instance.emit('open')
+      sendWsMessage({ type: 'auth_ok' })
+      sendWsMessage({ type: 'session_registered', sessionId: 'test-session-id-123' })
+      expect(mockPtySpawn).toHaveBeenCalledWith(
+        'claude',
+        expect.any(Array),
+        expect.objectContaining({ name: 'xterm-color' }),
+      )
+    })
+
+    it('session_registered が2回来ても PTY を1つしか起動しない', async () => {
+      await import('../index')
+      wsState.instance.emit('open')
+      sendWsMessage({ type: 'auth_ok' })
+      sendWsMessage({ type: 'session_registered', sessionId: 'session-1' })
+      sendWsMessage({ type: 'session_registered', sessionId: 'session-2' })
+      expect(mockPtySpawn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── メッセージ処理 ──────────────────────────────────────────────────────────
+
+  describe('メッセージ処理', () => {
+    async function setupWithShell() {
+      await import('../index')
+      wsState.instance.emit('open')
+      sendWsMessage({ type: 'auth_ok' })
+      sendWsMessage({ type: 'session_registered', sessionId: 'session-abc' })
+    }
+
+    it('input → PTY に書き込む', async () => {
+      await setupWithShell()
+      sendWsMessage({ type: 'input', data: 'hello\n' })
+      expect(mockPtyShell.instance.write).toHaveBeenCalledWith('hello\n')
+    })
+
+    it('resize → PTY をリサイズする', async () => {
+      await setupWithShell()
+      sendWsMessage({ type: 'resize', cols: 120, rows: 40 })
+      expect(mockPtyShell.instance.resize).toHaveBeenCalledWith(120, 40)
+    })
+
+    it('ping → pong を返す', async () => {
+      await import('../index')
+      wsState.instance.emit('open')
+      sendWsMessage({ type: 'auth_ok' })
+      mockWsSend.mockClear()
+      sendWsMessage({ type: 'ping' })
+      expect(mockWsSend).toHaveBeenCalledWith(JSON.stringify({ type: 'pong' }))
+    })
+
+    it('不正な JSON は無視する', async () => {
+      await import('../index')
+      wsState.instance.emit('open')
+      expect(() =>
+        wsState.instance.emit('message', Buffer.from('not json{')),
+      ).not.toThrow()
+    })
+  })
+
+  // ── PTY 終了 ───────────────────────────────────────────────────────────────
+
+  describe('PTY 終了', () => {
+    it('shell_exit を送信して WebSocket を閉じる', async () => {
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as any)
+      try {
+        await import('../index')
+        wsState.instance.emit('open')
+        sendWsMessage({ type: 'auth_ok' })
+        sendWsMessage({ type: 'session_registered', sessionId: 'session-abc' })
+
+        mockPtyShell.instance._onExitCb({ exitCode: 0 })
+
+        expect(mockWsSend).toHaveBeenCalledWith(
+          JSON.stringify({ type: 'shell_exit', exitCode: 0 }),
+        )
+        expect(mockWsClose).toHaveBeenCalled()
+      } finally {
+        mockExit.mockRestore()
+      }
+    })
+  })
+
+  // ── resolveToken ───────────────────────────────────────────────────────────
+
+  describe('resolveToken', () => {
+    it('環境変数 REMOCODER_TOKEN が最優先', async () => {
+      process.env.REMOCODER_TOKEN = 'env-token'
+      await import('../index')
+      wsState.instance.emit('open')
+      expect(mockWsSend).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'auth', token: 'env-token' }),
+      )
+    })
+
+    it('環境変数なし・ファイルあり → ファイルのトークンを使用', async () => {
+      delete process.env.REMOCODER_TOKEN
+      mockReadFileSync.mockReturnValue(JSON.stringify({ token: 'file-token' }))
+      await import('../index')
+      wsState.instance.emit('open')
+      expect(mockWsSend).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'auth', token: 'file-token' }),
+      )
+    })
+
+    it('環境変数なし・ファイルなし → process.exit(1)', async () => {
+      delete process.env.REMOCODER_TOKEN
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('no file')
+      })
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {
+          throw new Error('process.exit called')
+        }) as any)
+      try {
+        await expect(import('../index')).rejects.toThrow('process.exit called')
+        expect(mockExit).toHaveBeenCalledWith(1)
+      } finally {
+        mockExit.mockRestore()
+      }
+    })
+
+    it('ファイルのトークンが空文字列 → process.exit(1)', async () => {
+      delete process.env.REMOCODER_TOKEN
+      mockReadFileSync.mockReturnValue(JSON.stringify({ token: '' }))
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {
+          throw new Error('process.exit called')
+        }) as any)
+      try {
+        await expect(import('../index')).rejects.toThrow('process.exit called')
+        expect(mockExit).toHaveBeenCalledWith(1)
+      } finally {
+        mockExit.mockRestore()
+      }
+    })
+  })
+
+  // ── WebSocket エラー ────────────────────────────────────────────────────────
+
+  describe('WebSocket エラー', () => {
+    it('error イベント → process.exit(1)', async () => {
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {
+          throw new Error('process.exit called')
+        }) as any)
+      try {
+        await import('../index')
+        expect(() =>
+          wsState.instance.emit('error', new Error('connection refused')),
+        ).toThrow('process.exit called')
+        expect(mockExit).toHaveBeenCalledWith(1)
+      } finally {
+        mockExit.mockRestore()
+      }
+    })
+  })
+})

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@remocoder/shared': resolve(__dirname, '../shared/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+  },
+})

--- a/packages/desktop/src/main/__tests__/power-manager.test.ts
+++ b/packages/desktop/src/main/__tests__/power-manager.test.ts
@@ -1,0 +1,311 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mock references ──────────────────────────────────────────────────
+const mockGetPath = vi.hoisted(() => vi.fn(() => '/mock/userData'))
+const mockIsOnBatteryPower = vi.hoisted(() => vi.fn(() => false))
+const mockPowerMonitorOn = vi.hoisted(() => vi.fn())
+const mockBlockerStart = vi.hoisted(() => vi.fn(() => 99))
+const mockBlockerStop = vi.hoisted(() => vi.fn())
+const mockReadFileSync = vi.hoisted(() => vi.fn())
+const mockWriteFileSync = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  app: { getPath: mockGetPath },
+  powerMonitor: {
+    isOnBatteryPower: mockIsOnBatteryPower,
+    on: mockPowerMonitorOn,
+  },
+  powerSaveBlocker: {
+    start: mockBlockerStart,
+    stop: mockBlockerStop,
+  },
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}))
+
+vi.mock('path', () => ({
+  join: (...parts: string[]) => parts.join('/'),
+}))
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function createMockWindow() {
+  const windowHandlers: Record<string, () => void> = {}
+  return {
+    webContents: { send: vi.fn() },
+    on: vi.fn((event: string, cb: () => void) => {
+      windowHandlers[event] = cb
+    }),
+    _emit: (event: string) => windowHandlers[event]?.(),
+  }
+}
+
+/** initPowerManager 後に powerMonitor.on で登録されたハンドラを取得する */
+function capturePowerHandlers(): Record<string, () => void> {
+  const handlers: Record<string, () => void> = {}
+  for (const [event, cb] of mockPowerMonitorOn.mock.calls as [string, () => void][]) {
+    handlers[event] = cb
+  }
+  return handlers
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('power-manager', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockIsOnBatteryPower.mockReturnValue(false) // デフォルト: AC電源
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('no file')
+    })
+    mockBlockerStart.mockReturnValue(99)
+    mockBlockerStart.mockClear()
+    mockBlockerStop.mockClear()
+    mockWriteFileSync.mockClear()
+    mockPowerMonitorOn.mockClear()
+  })
+
+  // ── getPowerSettings ───────────────────────────────────────────────────────
+
+  describe('getPowerSettings', () => {
+    it('initPowerManager 前はデフォルト設定を返す', async () => {
+      const { getPowerSettings } = await import('../power-manager')
+      expect(getPowerSettings()).toEqual({ preventSleepOnAC: false, preventSleepOnBattery: false })
+    })
+
+    it('正常なファイルから設定を読み込む', async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ preventSleepOnAC: true, preventSleepOnBattery: false }),
+      )
+      const { initPowerManager, getPowerSettings } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      expect(getPowerSettings()).toEqual({ preventSleepOnAC: true, preventSleepOnBattery: false })
+    })
+
+    it('不正な JSON → デフォルト設定を返す', async () => {
+      mockReadFileSync.mockReturnValue('invalid{json')
+      const { initPowerManager, getPowerSettings } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      expect(getPowerSettings()).toEqual({ preventSleepOnAC: false, preventSleepOnBattery: false })
+    })
+
+    it('型が不正な設定 → デフォルト設定を返す', async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ preventSleepOnAC: 'yes', preventSleepOnBattery: 1 }),
+      )
+      const { initPowerManager, getPowerSettings } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      expect(getPowerSettings()).toEqual({ preventSleepOnAC: false, preventSleepOnBattery: false })
+    })
+
+    it('設定ファイルのパスに userData を使用する', async () => {
+      const { initPowerManager } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      expect(mockGetPath).toHaveBeenCalledWith('userData')
+    })
+  })
+
+  // ── getPowerStatus ─────────────────────────────────────────────────────────
+
+  describe('getPowerStatus', () => {
+    it('初期状態: AC電源・ブロッカー非アクティブ', async () => {
+      const { getPowerStatus } = await import('../power-manager')
+      expect(getPowerStatus()).toEqual({ isOnAC: true, isBlockerActive: false })
+    })
+
+    it('initPowerManager でバッテリー状態を反映する', async () => {
+      mockIsOnBatteryPower.mockReturnValue(true)
+      const { initPowerManager, getPowerStatus } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      expect(getPowerStatus()).toEqual({ isOnAC: false, isBlockerActive: false })
+    })
+
+    it('ブロッカー起動後は isBlockerActive=true', async () => {
+      const { initPowerManager, setPowerSetting, getPowerStatus } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnAC', true)
+      expect(getPowerStatus().isBlockerActive).toBe(true)
+    })
+  })
+
+  // ── setPowerSetting ────────────────────────────────────────────────────────
+
+  describe('setPowerSetting', () => {
+    it('設定を更新して正しいパスに永続化する', async () => {
+      const { setPowerSetting, getPowerSettings } = await import('../power-manager')
+      setPowerSetting('preventSleepOnBattery', true)
+      expect(getPowerSettings()).toEqual({ preventSleepOnAC: false, preventSleepOnBattery: true })
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '/mock/userData/power-settings.json',
+        JSON.stringify({ preventSleepOnAC: false, preventSleepOnBattery: true }),
+        'utf-8',
+      )
+    })
+
+    it('元の設定オブジェクトを変更しない（イミュータブル）', async () => {
+      const { getPowerSettings, setPowerSetting } = await import('../power-manager')
+      const before = getPowerSettings()
+      setPowerSetting('preventSleepOnAC', true)
+      expect(before.preventSleepOnAC).toBe(false)
+    })
+  })
+
+  // ── applyBlocker ───────────────────────────────────────────────────────────
+
+  describe('applyBlocker', () => {
+    it('AC電源 + preventSleepOnAC=true → ブロッカー開始', async () => {
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnAC', true)
+      expect(mockBlockerStart).toHaveBeenCalledWith('prevent-display-sleep')
+    })
+
+    it('AC電源 + preventSleepOnAC=false → ブロッカー開始しない', async () => {
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnAC', false)
+      expect(mockBlockerStart).not.toHaveBeenCalled()
+    })
+
+    it('AC電源 + preventSleepOnBattery=true → ブロッカー開始しない', async () => {
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnBattery', true)
+      expect(mockBlockerStart).not.toHaveBeenCalled()
+    })
+
+    it('バッテリー + preventSleepOnBattery=true → ブロッカー開始', async () => {
+      mockIsOnBatteryPower.mockReturnValue(true)
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnBattery', true)
+      expect(mockBlockerStart).toHaveBeenCalledWith('prevent-display-sleep')
+    })
+
+    it('バッテリー + preventSleepOnAC=true → ブロッカー開始しない', async () => {
+      mockIsOnBatteryPower.mockReturnValue(true)
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnAC', true)
+      expect(mockBlockerStart).not.toHaveBeenCalled()
+    })
+
+    it('ブロッカー起動中に shouldBlock=false → 停止する（冪等）', async () => {
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnAC', true) // start
+      expect(mockBlockerStart).toHaveBeenCalledTimes(1)
+      setPowerSetting('preventSleepOnAC', false) // stop
+      expect(mockBlockerStop).toHaveBeenCalledWith(99)
+    })
+
+    it('ブロッカー停止中に shouldBlock=false → stop を呼ばない（冪等）', async () => {
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnAC', false)
+      expect(mockBlockerStop).not.toHaveBeenCalled()
+    })
+
+    it('ブロッカー起動中に再度 shouldBlock=true → 二重起動しない', async () => {
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      initPowerManager(createMockWindow() as any)
+      setPowerSetting('preventSleepOnAC', true)
+      setPowerSetting('preventSleepOnAC', true) // 2回目
+      expect(mockBlockerStart).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── powerMonitor イベント ──────────────────────────────────────────────────
+
+  describe('powerMonitor イベント', () => {
+    it('on-ac イベント → isOnAC=true になりレンダラーに通知する', async () => {
+      mockIsOnBatteryPower.mockReturnValue(true) // バッテリー状態で起動
+      const { initPowerManager, getPowerStatus } = await import('../power-manager')
+      const win = createMockWindow() as any
+      initPowerManager(win)
+      const handlers = capturePowerHandlers()
+
+      handlers['on-ac']()
+
+      expect(getPowerStatus().isOnAC).toBe(true)
+      expect(win.webContents.send).toHaveBeenCalledWith('power-status-changed', {
+        isOnAC: true,
+        isBlockerActive: false,
+      })
+    })
+
+    it('on-battery イベント → isOnAC=false になりレンダラーに通知する', async () => {
+      const { initPowerManager, getPowerStatus } = await import('../power-manager')
+      const win = createMockWindow() as any
+      initPowerManager(win)
+      const handlers = capturePowerHandlers()
+
+      handlers['on-battery']()
+
+      expect(getPowerStatus().isOnAC).toBe(false)
+      expect(win.webContents.send).toHaveBeenCalledWith('power-status-changed', {
+        isOnAC: false,
+        isBlockerActive: false,
+      })
+    })
+
+    it('on-ac イベント + preventSleepOnAC=true → ブロッカー起動してレンダラーに通知', async () => {
+      mockIsOnBatteryPower.mockReturnValue(true) // バッテリー状態で起動
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      const win = createMockWindow() as any
+      initPowerManager(win)
+      setPowerSetting('preventSleepOnAC', true)
+      const handlers = capturePowerHandlers()
+
+      handlers['on-ac']()
+
+      expect(mockBlockerStart).toHaveBeenCalledWith('prevent-display-sleep')
+      expect(win.webContents.send).toHaveBeenLastCalledWith('power-status-changed', {
+        isOnAC: true,
+        isBlockerActive: true,
+      })
+    })
+
+    it('on-battery イベント + preventSleepOnBattery=false → ブロッカー停止', async () => {
+      const { initPowerManager, setPowerSetting } = await import('../power-manager')
+      const win = createMockWindow() as any
+      initPowerManager(win)
+      setPowerSetting('preventSleepOnAC', true) // AC時にブロッカー起動
+      const handlers = capturePowerHandlers()
+
+      handlers['on-battery']() // バッテリーに切り替え → preventSleepOnBattery=false なので停止
+
+      expect(mockBlockerStop).toHaveBeenCalledWith(99)
+    })
+  })
+
+  // ── ウィンドウ closed ──────────────────────────────────────────────────────
+
+  describe('ウィンドウ closed イベント', () => {
+    it('ブロッカー起動中にウィンドウが閉じられる → 停止する', async () => {
+      const { initPowerManager, setPowerSetting, getPowerStatus } = await import('../power-manager')
+      const win = createMockWindow() as any
+      initPowerManager(win)
+      setPowerSetting('preventSleepOnAC', true)
+
+      win._emit('closed')
+
+      expect(mockBlockerStop).toHaveBeenCalledWith(99)
+      expect(getPowerStatus().isBlockerActive).toBe(false)
+    })
+
+    it('ブロッカー停止中にウィンドウが閉じられる → stop を呼ばない', async () => {
+      const { initPowerManager } = await import('../power-manager')
+      const win = createMockWindow() as any
+      initPowerManager(win)
+
+      win._emit('closed')
+
+      expect(mockBlockerStop).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/mobile/src/__tests__/utils.test.ts
+++ b/packages/mobile/src/__tests__/utils.test.ts
@@ -1,0 +1,43 @@
+import { formatDate, getSessionDisplayName } from '../utils'
+
+describe('formatDate', () => {
+  it('ISO日付文字列を日本語の月日時分形式でフォーマットする', () => {
+    const result = formatDate('2024-06-15T09:30:00.000Z')
+    expect(result).toMatch(/\d+月\d+日/)
+    expect(result).toMatch(/\d{2}:\d{2}/)
+  })
+
+  it('不正な日付文字列でも例外を投げない', () => {
+    expect(() => formatDate('not-a-date')).not.toThrow()
+  })
+
+  it('文字列を返す', () => {
+    expect(typeof formatDate('2024-01-01T00:00:00.000Z')).toBe('string')
+  })
+})
+
+describe('getSessionDisplayName', () => {
+  it('projectPath のベース名（末尾セグメント）を返す', () => {
+    expect(getSessionDisplayName({ projectPath: '/home/user/my-project' })).toBe('my-project')
+  })
+
+  it('深いネストのパスでも末尾セグメントを返す', () => {
+    expect(getSessionDisplayName({ projectPath: '/a/b/c/deep-project' })).toBe('deep-project')
+  })
+
+  it('末尾スラッシュ付きパスでもベース名を返す', () => {
+    expect(getSessionDisplayName({ projectPath: '/home/user/project/' })).toBe('project')
+  })
+
+  it('projectPath が undefined の場合 "セッション" を返す', () => {
+    expect(getSessionDisplayName({ projectPath: undefined })).toBe('セッション')
+  })
+
+  it('projectPath が空文字列の場合 "セッション" を返す', () => {
+    expect(getSessionDisplayName({ projectPath: '' })).toBe('セッション')
+  })
+
+  it('ルートパス "/" の場合 "セッション" を返す', () => {
+    expect(getSessionDisplayName({ projectPath: '/' })).toBe('セッション')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.0.0
-        version: 29.7.0(@types/node@25.4.0)
+        version: 29.7.0(@types/node@20.19.37)
       ts-jest:
         specifier: ^29.0.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.4.0))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
       turbo:
         specifier: ^2.0.0
         version: 2.8.16
@@ -42,6 +42,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.37)(jsdom@24.1.3)(lightningcss@1.32.0)(terser@5.46.0)
 
   packages/desktop:
     dependencies:
@@ -181,7 +184,7 @@ importers:
         version: 55.0.6
       '@testing-library/react-native':
         specifier: ^12.4.0
-        version: 12.9.0(jest@29.7.0(@types/node@20.19.37))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react-test-renderer@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 12.9.0(jest@29.7.0(@types/node@25.4.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react-test-renderer@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/jest':
         specifier: ^29.0.0
         version: 29.5.14
@@ -196,13 +199,13 @@ importers:
         version: 55.0.11(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@55.0.6)(react-refresh@0.14.2)
       jest:
         specifier: ^29.0.0
-        version: 29.7.0(@types/node@20.19.37)
+        version: 29.7.0(@types/node@25.4.0)
       react-test-renderer:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       ts-jest:
         specifier: ^29.0.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.4.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -6803,7 +6806,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@12.9.0(jest@29.7.0(@types/node@20.19.37))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react-test-renderer@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@testing-library/react-native@12.9.0(jest@29.7.0(@types/node@25.4.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react-test-renderer@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       jest-matcher-utils: 29.7.0
       pretty-format: 29.7.0
@@ -6812,7 +6815,7 @@ snapshots:
       react-test-renderer: 19.2.4(react@19.2.4)
       redent: 3.0.0
     optionalDependencies:
-      jest: 29.7.0(@types/node@20.19.37)
+      jest: 29.7.0(@types/node@25.4.0)
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -7016,6 +7019,14 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.4.0)(lightningcss@1.32.0)(terser@5.46.0))':
     dependencies:
@@ -10945,6 +10956,24 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
+  vite-node@2.1.9(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.9(@types/node@25.4.0)(lightningcss@1.32.0)(terser@5.46.0):
     dependencies:
       cac: 6.7.14
@@ -10963,6 +10992,17 @@ snapshots:
       - supports-color
       - terser
 
+  vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      terser: 5.46.0
+
   vite@5.4.21(@types/node@25.4.0)(lightningcss@1.32.0)(terser@5.46.0):
     dependencies:
       esbuild: 0.21.5
@@ -10973,6 +11013,42 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
       terser: 5.46.0
+
+  vitest@2.1.9(@types/node@20.19.37)(jsdom@24.1.3)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@2.1.9(@types/node@25.4.0)(jsdom@24.1.3)(lightningcss@1.32.0)(terser@5.46.0):
     dependencies:


### PR DESCRIPTION
## Summary

- **desktop**: `power-manager.ts` のテストを新規作成（30テスト）。`applyBlocker` の冪等性、AC/バッテリー別スリープ抑制ロジック、`on-ac`/`on-battery` イベント、ウィンドウ `closed` 時のブロッカー停止、設定ファイルの読み書きを網羅
- **mobile**: `utils.ts` のテストを新規作成（7テスト）。`formatDate` / `getSessionDisplayName` の境界値テスト（末尾スラッシュ、空文字、undefinedなど）
- **cli**: vitest 環境を整備（`vitest.config.ts`・`package.json` 更新）し `index.ts` のテストを新規作成（16テスト）。認証フロー、エラー処理、メッセージハンドラ、`resolveToken` の優先順位を網羅

## Test plan

- [ ] `pnpm test` で全パッケージのテストが通ることを確認
- [ ] `power-manager` テスト: AC/バッテリー切り替え時のブロッカー動作が正しいこと
- [ ] CLI テスト: WebSocket メッセージハンドラと `resolveToken` のフォールバック動作が正しいこと
- [ ] mobile utils テスト: `getSessionDisplayName` のエッジケース（`/`・空文字・undefined）が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)