### PR TITLE
feat(shared): チャットUI向け cc_* WebSocket メッセージ型定義を追加 (#53)

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -84,13 +84,15 @@ export const DEFAULT_WS_PORT = 8080
 /** Claude Code SDK が発行するメッセージのロール */
 export type CcRole = 'assistant' | 'user'
 
-/** アシスタントのテキスト返答 */
+/** チャットメッセージ（アシスタントまたはユーザー） */
 export interface CcMessage {
   type: 'cc_message'
   id: string
   role: CcRole
   content: string
   sessionId: string
+  /** メッセージ生成時刻 (ISO 8601) */
+  timestamp?: string
 }
 
 /** ツール実行リクエスト（Claude → ツール） */
@@ -106,6 +108,7 @@ export interface CcToolUse {
 export interface CcToolResult {
   type: 'cc_tool_result'
   toolUseId: string
+  /** テキスト形式のツール実行結果（バイナリ・画像等は含まない） */
   content: string
   isError: boolean
   sessionId: string


### PR DESCRIPTION
## Summary

- `CcMessage` / `CcToolUse` / `CcToolResult` / `CcPermissionRequest` / `CcPermissionResponse` / `CcSessionStart` / `CcSessionEnd` / `CcUserInput` を `WsMessage` union に追加
- 既存の PTY 系型（`output`, `input`, `resize` 等）は後方互換のため維持

Closes #53
Part of #52

## Test plan
- [ ] `npx tsc --noEmit` が packages/shared でパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)