### PR TITLE
fix: CIエラーを修正（Windows/Ubuntu削除、macOS/iOS/Android対応）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,6 @@ jobs:
         include:
           - os: macos-latest
             dist_args: --mac
-          - os: windows-latest
-            dist_args: --win
-          - os: ubuntu-latest
-            dist_args: --linux
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -64,9 +60,17 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           PLATFORM: ${{ matrix.platform }}
         run: |
-          eas build \
-            --platform "$PLATFORM" \
-            --profile production \
-            --non-interactive \
-            --auto-submit \
-            --no-wait
+          if [[ "$PLATFORM" == "android" ]]; then
+            eas build \
+              --platform "$PLATFORM" \
+              --profile production \
+              --non-interactive \
+              --auto-submit \
+              --no-wait
+          else
+            eas build \
+              --platform "$PLATFORM" \
+              --profile production \
+              --non-interactive \
+              --no-wait
+          fi


### PR DESCRIPTION
## Summary

- `release.yml`: Windows・Ubuntu の Electron ビルドジョブを削除
- `ci.yml`: macOS DMG ビルドジョブに `GH_TOKEN` を設定（electron-builder がCI環境を検知して自動publishしようとする際に `GH_TOKEN` が未設定でエラーになっていた問題を修正）
- `release.yml`: iOS EAS ビルドから `--auto-submit` を除外（App Store Connect API Keysが非対話モードで設定できないエラーを修正）。Androidは引き続き `--auto-submit` を使用。

## Test plan

- [ ] タグ付きプッシュで `Release` ワークフローが macOS DMG ビルドのみ実行されることを確認
- [ ] `Release` ワークフローで iOS EAS ビルドが成功することを確認
- [ ] `Release` ワークフローで Android EAS ビルド & Submit が成功することを確認
- [ ] `CI` ワークフローの macOS DMG ビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)