### PR TITLE
fix: release.yml CI エラー修正（権限・Xcode・versionCode）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     name: Electron Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     environment: production
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -106,6 +108,10 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26'
 
       # EAS クラウドビルド（月次クレジット上限のためコメントアウト）
       # - name: Build and Submit on EAS cloud (ios)

--- a/packages/mobile/app.config.js
+++ b/packages/mobile/app.config.js
@@ -1,0 +1,14 @@
+module.exports = ({ config }) => {
+  const version = config.version || '0.0.1'
+  const [major, minor, patch] = version.split('.').map(Number)
+  // versionCode: MAJOR*1000000 + MINOR*1000 + PATCH (各セグメント最大999まで単調増加を保証)
+  const versionCode = major * 1000000 + minor * 1000 + patch
+
+  return {
+    ...config,
+    android: {
+      ...config.android,
+      versionCode,
+    },
+  }
+}

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 10.0.0",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "submit": {
     "production": {


### PR DESCRIPTION
closes #69

## 変更内容

### 1. Electron Build: GitHub Release 作成 403 エラーを修正
`electron-build` ジョブに `permissions: contents: write` を追加。

### 2. EAS Local Build (iOS): Xcode バージョンを 26 に固定
`maxim-lobanov/setup-xcode@v1` で `xcode-version: '26'` を指定し、Expo SDK 55 が要求する Xcode >= 26.0.0 に対応。

### 3. Android versionCode を version から自動生成
- `packages/mobile/app.config.js` を新規追加
- 計算式: `MAJOR * 1000000 + MINOR * 1000 + PATCH`（各セグメント最大 999 まで単調増加を保証）
  - `0.0.3` → 3 / `0.1.0` → 1000 / `1.0.0` → 1000000
- `eas.json` の `appVersionSource` を `remote` → `local` に変更し、`app.config.js` の計算値が EAS に上書きされないよう修正

## Test plan
- [ ] `v*` タグを push して release.yml が全ジョブ成功することを確認
- [ ] Android ビルドで `versionCode` が version と一致した値になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)