### PR TITLE
Add chat UI for Claude sessions with stream-json parsing

### DIFF
--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -144,6 +144,8 @@ interface PtySession {
   permissionBuffer: string
   /** 承認待ちリクエスト（存在する間は重複検出しない） */
   pendingPermission: { requestId: string; timeoutId: ReturnType<typeof setTimeout>; style: 'numbered' | 'legacy'; requiresAlways: boolean } | null
+  /** stream-json改行バッファ（claudeセッションのみ使用） */
+  jsonLineBuffer: string
 }
 
 /** 永続PTYセッションマップ（WS切断後も保持） */
@@ -321,7 +323,10 @@ function createPtySession(source: SessionSource = { kind: 'claude' }, clientIP?:
     source,
     permissionBuffer: '',
     pendingPermission: null,
+    jsonLineBuffer: '',
   }
+
+  const isClaudeSession = source.kind === 'claude'
 
   ptyProc.onData((data) => {
     appendScrollback(session, data)
@@ -330,6 +335,9 @@ function createPtySession(source: SessionSource = { kind: 'claude' }, clientIP?:
     }
     serverCallbacks.onPtyOutput?.(id, data)
     detectAndSendPermission(session, data)
+    if (isClaudeSession) {
+      parseAndSendChatMessages(session, data)
+    }
   })
 
   ptyProc.onExit(({ exitCode }) => {
@@ -371,6 +379,7 @@ function createExternalSession(providerWs: WebSocket): PtySession {
     lastActiveAt: 0,
     permissionBuffer: '',
     pendingPermission: null,
+    jsonLineBuffer: '',
   }
 
   ptySessions.set(id, session)
@@ -775,14 +784,137 @@ function assertSafeSessionName(name: string, tool: string): void {
   }
 }
 
+// ─── stream-json チャットメッセージパーサー ───────────────────────────────────
+
+/**
+ * PTY出力チャンクから NDJSON 行を切り出し、チャットメッセージに変換して送信する。
+ * claudeセッション（--output-format stream-json）専用。
+ */
+function parseAndSendChatMessages(session: PtySession, data: string): void {
+  if (session.wsClient?.readyState !== WebSocket.OPEN) {
+    // バッファだけ消費して返す
+    session.jsonLineBuffer += data
+    const lines = session.jsonLineBuffer.split('\n')
+    session.jsonLineBuffer = lines.pop() ?? ''
+    return
+  }
+
+  session.jsonLineBuffer += data
+  const lines = session.jsonLineBuffer.split('\n')
+  session.jsonLineBuffer = lines.pop() ?? ''
+
+  for (const line of lines) {
+    const clean = stripAnsi(line).trim()
+    if (!clean.startsWith('{')) continue
+    let event: Record<string, unknown>
+    try {
+      event = JSON.parse(clean)
+    } catch {
+      continue
+    }
+    const msgs = streamJsonEventToWsMessages(event)
+    for (const msg of msgs) {
+      session.wsClient.send(JSON.stringify(msg))
+    }
+  }
+}
+
+/**
+ * claude --output-format stream-json の1イベントを WsMessage[] に変換する。
+ * 不明なイベントは空配列を返す。
+ */
+export function streamJsonEventToWsMessages(event: Record<string, unknown>): WsMessage[] {
+  if (!event || typeof event.type !== 'string') return []
+
+  switch (event.type) {
+    case 'system': {
+      if ((event.subtype as string | undefined) === 'init') {
+        return [{
+          type: 'chat_ready',
+          sessionId: String(event.session_id ?? ''),
+          cwd: String(event.cwd ?? ''),
+        }]
+      }
+      return []
+    }
+
+    case 'assistant': {
+      const msg = event.message as { content?: unknown[] } | undefined
+      if (!Array.isArray(msg?.content)) return []
+      const results: WsMessage[] = []
+      let textAccum = ''
+
+      for (const part of msg.content as Record<string, unknown>[]) {
+        if (part.type === 'text' && part.text) {
+          textAccum += String(part.text)
+        } else if (part.type === 'tool_use') {
+          if (textAccum) {
+            results.push({ type: 'chat_assistant_message', content: textAccum })
+            textAccum = ''
+          }
+          results.push({
+            type: 'chat_tool_use',
+            toolName: String(part.name ?? ''),
+            toolInput: JSON.stringify(part.input ?? {}, null, 2),
+          })
+        }
+      }
+      if (textAccum) {
+        results.push({ type: 'chat_assistant_message', content: textAccum })
+      }
+      return results
+    }
+
+    case 'user': {
+      // ツール結果はユーザーメッセージ内の tool_result コンテンツとして届く
+      const msg = event.message as { content?: unknown[] } | undefined
+      if (!Array.isArray(msg?.content)) return []
+      const results: WsMessage[] = []
+
+      for (const part of msg.content as Record<string, unknown>[]) {
+        if (part.type === 'tool_result') {
+          const raw = part.content
+          const content = Array.isArray(raw)
+            ? (raw as Record<string, unknown>[])
+                .filter((c) => c.type === 'text')
+                .map((c) => String(c.text ?? ''))
+                .join('')
+            : String(raw ?? '')
+          results.push({
+            type: 'chat_tool_result',
+            toolName: String(part.tool_use_id ?? ''),
+            content: content.slice(0, 2000),
+            isError: Boolean(part.is_error),
+          })
+        }
+      }
+      return results
+    }
+
+    case 'result': {
+      return [{ type: 'chat_status', status: 'idle' }]
+    }
+
+    default:
+      return []
+  }
+}
+
+// ─── PTY スポーン ─────────────────────────────────────────────────────────────
+
 function spawnSource(source: SessionSource): pty.IPty {
   const baseOpts = { name: 'xterm-color', cols: 80, rows: 30, env: { ...process.env } }
   switch (source.kind) {
     case 'claude': {
       const loginShell = resolveShell()
       const cwd = source.projectPath && existsSync(source.projectPath) ? source.projectPath : undefined
-      console.log(`[pty-server] Spawning claude via shell: ${loginShell}${cwd ? ` (cwd: ${cwd})` : ''}`)
-      return pty.spawn(loginShell, ['-lc', 'exec claude'], { ...baseOpts, ...(cwd ? { cwd } : {}) })
+      console.log(`[pty-server] Spawning claude (stream-json) via shell: ${loginShell}${cwd ? ` (cwd: ${cwd})` : ''}`)
+      // --output-format stream-json: 構造化JSONを出力。cols=220でJSON行の折り返しを防ぐ
+      return pty.spawn(loginShell, ['-lc', 'exec claude --output-format stream-json'], {
+        ...baseOpts,
+        cols: 220,
+        ...(cwd ? { cwd } : {}),
+      })
     }
     case 'tmux': {
       assertSafeSessionName(source.sessionName, 'tmux')

--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -5,11 +5,12 @@ import { ConnectScreen } from './screens/ConnectScreen'
 import { ForceUpdateScreen } from './screens/ForceUpdateScreen'
 import { SessionPickerScreen } from './screens/SessionPickerScreen'
 import { TerminalScreen } from './screens/TerminalScreen'
+import { ChatScreen } from './screens/ChatScreen'
 import { useForceUpdate } from './hooks/useForceUpdate'
 import { useOTAUpdate } from './hooks/useOTAUpdate'
 import { SessionSource } from '@remocoder/shared'
 
-type Screen = 'connect' | 'sessionPicker' | 'terminal'
+type Screen = 'connect' | 'sessionPicker' | 'terminal' | 'chat'
 
 interface AppState {
   screen: Screen
@@ -38,14 +39,18 @@ export default function App() {
   }
 
   const handleSelectProject = (projectPath: string | null) => {
-    setState((prev) => ({ ...prev, screen: 'terminal', projectPath, sessionId: null }))
+    // 新規 claude セッション → チャットUI
+    setState((prev) => ({ ...prev, screen: 'chat', projectPath, sessionId: null, source: null }))
   }
 
-  const handleAttachSession = (sessionId: string) => {
-    setState((prev) => ({ ...prev, screen: 'terminal', sessionId, projectPath: null, source: null }))
+  const handleAttachSession = (sessionId: string, source?: SessionSource) => {
+    // claude セッションへのアタッチ → チャットUI、それ以外はターミナル
+    const screen = source?.kind === 'claude' || source == null ? 'chat' : 'terminal'
+    setState((prev) => ({ ...prev, screen, sessionId, projectPath: null, source: source ?? null }))
   }
 
   const handleAttachMultiplexer = (source: SessionSource) => {
+    // tmux / screen / zellij → ターミナルUI
     setState((prev) => ({ ...prev, screen: 'terminal', source, sessionId: null, projectPath: null }))
   }
 
@@ -88,6 +93,15 @@ export default function App() {
           onAttachSession={handleAttachSession}
           onAttachMultiplexer={handleAttachMultiplexer}
           onBack={handleBack}
+        />
+      )}
+      {state.screen === 'chat' && (
+        <ChatScreen
+          ip={state.ip}
+          token={state.token}
+          projectPath={state.projectPath}
+          sessionId={state.sessionId}
+          onDisconnect={handleDisconnect}
         />
       )}
       {state.screen === 'terminal' && (

--- a/packages/mobile/src/__mocks__/react-native.ts
+++ b/packages/mobile/src/__mocks__/react-native.ts
@@ -32,6 +32,8 @@ const Button = ({ title, onPress, disabled, testID }: any) =>
   )
 
 // FlatList renders each item via renderItem
+const KeyboardAvoidingView = (props: any) => React.createElement('View', props)
+
 const FlatList = ({ data, renderItem, keyExtractor }: any) =>
   React.createElement(
     'View',
@@ -100,6 +102,7 @@ export {
   Modal,
   Button,
   FlatList,
+  KeyboardAvoidingView,
   Alert,
   Linking,
   StyleSheet,

--- a/packages/mobile/src/__tests__/App.test.tsx
+++ b/packages/mobile/src/__tests__/App.test.tsx
@@ -3,6 +3,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react-nativ
 import App from '../App'
 import AsyncStorage from '../__mocks__/async-storage'
 
+// useForceUpdate の fetch をモック（ネットワーク失敗 → isChecking: false になる）
+;(globalThis as Record<string, unknown>).fetch = jest.fn().mockRejectedValue(new TypeError('Network request failed'))
+
 // SessionPickerScreen が使う WebSocket をモック
 const mockWs = {
   send: jest.fn(),
@@ -63,7 +66,7 @@ describe('App', () => {
     expect(screen.getByText('MacBook')).toBeTruthy()
   })
 
-  it('onSelectProject(path) → TerminalScreen が projectPath 付きでレンダーされる', async () => {
+  it('onSelectProject(path) → ChatScreen が projectPath 付きでレンダーされる', async () => {
     const profiles = [{ id: '1', name: 'MacBook', ip: '100.64.0.1', token: 'tok' }]
     AsyncStorage.getItem.mockResolvedValue(JSON.stringify(profiles))
     AsyncStorage.setItem.mockResolvedValue(undefined)
@@ -95,7 +98,7 @@ describe('App', () => {
     expect(screen.getByText('接続中...')).toBeTruthy()
   })
 
-  it('onAttachSession(sessionId) → TerminalScreen に sessionId が渡される', async () => {
+  it('onAttachSession(sessionId) → source なし(claude扱い)なので ChatScreen が表示される', async () => {
     const profiles = [{ id: '1', name: 'MacBook', ip: '100.64.0.1', token: 'tok' }]
     AsyncStorage.getItem.mockResolvedValue(JSON.stringify(profiles))
     AsyncStorage.setItem.mockResolvedValue(undefined)

--- a/packages/mobile/src/hooks/useWebSocket.ts
+++ b/packages/mobile/src/hooks/useWebSocket.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { DEFAULT_WS_PORT, WsMessage } from '@remocoder/shared'
+
+// 接続試行タイムアウト（ms）
+const CONNECT_TIMEOUT = 10000
+// 最大再接続遅延（ms）
+const MAX_RECONNECT_DELAY = 30000
+// キープアライブ間隔（ms）
+const KEEPALIVE_INTERVAL = 30000
+
+export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'auth_error' | 'disconnected'
+
+export interface UseWebSocketOptions {
+  ip: string
+  token: string
+  onMessage: (msg: WsMessage) => void
+}
+
+export interface UseWebSocketResult {
+  send: (msg: WsMessage) => void
+  status: ConnectionStatus
+}
+
+/**
+ * ネイティブ WebSocket を使った接続管理フック。
+ * 認証・再接続・ping/pong キープアライブを担当する。
+ * 認証後の session_create などの高レベルなフローは呼び出し元が担当する。
+ */
+export function useWebSocket({ ip, token, onMessage }: UseWebSocketOptions): UseWebSocketResult {
+  const [status, setStatus] = useState<ConnectionStatus>('connecting')
+
+  // 最新の onMessage を ref で保持（再レンダリングで再接続させない）
+  const onMessageRef = useRef(onMessage)
+  onMessageRef.current = onMessage
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectDelayRef = useRef(1000)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const keepaliveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // 認証エラー・セッション終了後は自動再接続しない
+  const noReconnectRef = useRef(false)
+
+  const clearTimers = useCallback(() => {
+    if (reconnectTimerRef.current) { clearTimeout(reconnectTimerRef.current); reconnectTimerRef.current = null }
+    if (connectTimerRef.current) { clearTimeout(connectTimerRef.current); connectTimerRef.current = null }
+    if (keepaliveTimerRef.current) { clearInterval(keepaliveTimerRef.current); keepaliveTimerRef.current = null }
+  }, [])
+
+  const send = useCallback((msg: WsMessage) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(msg))
+    }
+  }, [])
+
+  useEffect(() => {
+    noReconnectRef.current = false
+    reconnectDelayRef.current = 1000
+
+    function connect() {
+      if (noReconnectRef.current) return
+
+      clearTimers()
+      setStatus('connecting')
+
+      const ws = new WebSocket(`ws://${ip}:${DEFAULT_WS_PORT}`)
+      wsRef.current = ws
+
+      // 接続タイムアウト
+      connectTimerRef.current = setTimeout(() => {
+        if (ws.readyState === WebSocket.CONNECTING) {
+          ws.close()
+        }
+      }, CONNECT_TIMEOUT)
+
+      ws.onopen = () => {
+        if (connectTimerRef.current) { clearTimeout(connectTimerRef.current); connectTimerRef.current = null }
+        reconnectDelayRef.current = 1000
+        ws.send(JSON.stringify({ type: 'auth', token } satisfies WsMessage))
+      }
+
+      ws.onmessage = (e: MessageEvent) => {
+        let msg: WsMessage
+        try {
+          msg = JSON.parse(e.data as string)
+        } catch {
+          return
+        }
+
+        if (msg.type === 'auth_ok') {
+          setStatus('connected')
+          // キープアライブ開始
+          keepaliveTimerRef.current = setInterval(() => {
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.send(JSON.stringify({ type: 'ping' } satisfies WsMessage))
+            }
+          }, KEEPALIVE_INTERVAL)
+        } else if (msg.type === 'auth_error') {
+          noReconnectRef.current = true
+          setStatus('auth_error')
+        } else if (msg.type === 'shell_exit') {
+          noReconnectRef.current = true
+          setStatus('disconnected')
+        } else if (msg.type === 'ping') {
+          ws.send(JSON.stringify({ type: 'pong' } satisfies WsMessage))
+        }
+
+        onMessageRef.current(msg)
+      }
+
+      ws.onclose = () => {
+        clearTimers()
+        if (noReconnectRef.current) return
+
+        setStatus('reconnecting')
+        const delay = reconnectDelayRef.current
+        reconnectTimerRef.current = setTimeout(() => {
+          reconnectDelayRef.current = Math.min(delay * 2, MAX_RECONNECT_DELAY)
+          connect()
+        }, delay)
+      }
+
+      ws.onerror = () => {
+        // onclose が続けて呼ばれるので再接続はそちらで処理
+      }
+    }
+
+    connect()
+
+    return () => {
+      noReconnectRef.current = true
+      clearTimers()
+      wsRef.current?.close()
+      wsRef.current = null
+    }
+  }, [ip, token, clearTimers])
+
+  return { send, status }
+}

--- a/packages/mobile/src/screens/ChatScreen.tsx
+++ b/packages/mobile/src/screens/ChatScreen.tsx
@@ -1,0 +1,479 @@
+import React, { useCallback, useRef, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { ProjectInfo, SessionInfo, SessionSource, WsMessage } from '@remocoder/shared'
+import { PermissionSheet, PermissionRequest } from '../components/PermissionSheet'
+import { SessionSwitcherModal } from '../components/SessionSwitcherModal'
+import { useWebSocket, ConnectionStatus } from '../hooks/useWebSocket'
+
+// ─── チャットアイテム型 ────────────────────────────────────────────────────────
+
+// id なしのデータ部分（Omit<Union, key> は分配されないため個別定義）
+type ChatItemData =
+  | { kind: 'user'; content: string }
+  | { kind: 'assistant'; content: string }
+  | { kind: 'tool_use'; toolName: string; toolInput: string }
+  | { kind: 'tool_result'; toolName: string; content: string; isError: boolean }
+  | { kind: 'system'; content: string }
+
+type ChatItem = ChatItemData & { id: string }
+
+let _idCounter = 0
+function nextId() { return String(++_idCounter) }
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  ip: string
+  token: string
+  projectPath?: string | null
+  /** アタッチする既存セッションID。指定時は projectPath より優先 */
+  sessionId?: string | null
+  onDisconnect: () => void
+}
+
+// ─── ステータスバー設定 ────────────────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<ConnectionStatus, { label: string; color: string; bgColor: string }> = {
+  connecting:   { label: '接続中...',     color: '#d4d4d4', bgColor: 'rgba(100,100,100,0.8)' },
+  connected:    { label: '接続済み',      color: '#4ec9b0', bgColor: 'rgba(0,80,60,0.8)' },
+  reconnecting: { label: '再接続中...',   color: '#dcdcaa', bgColor: 'rgba(80,70,0,0.8)' },
+  auth_error:   { label: '認証エラー',    color: '#f44747', bgColor: 'rgba(80,0,0,0.8)' },
+  disconnected: { label: 'セッション終了', color: '#d4d4d4', bgColor: 'rgba(50,50,50,0.8)' },
+}
+
+// ─── メインコンポーネント ─────────────────────────────────────────────────────
+
+export function ChatScreen({ ip, token, projectPath, sessionId, onDisconnect }: Props) {
+  const [messages, setMessages] = useState<ChatItem[]>([])
+  const [inputText, setInputText] = useState('')
+  const [isThinking, setIsThinking] = useState(false)
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null)
+  const [pendingPermission, setPendingPermission] = useState<PermissionRequest | null>(null)
+  const [showSwitcher, setShowSwitcher] = useState(false)
+  const [switcherLoading, setSwitcherLoading] = useState(false)
+  const [sessionList, setSessionList] = useState<SessionInfo[]>([])
+  const [projectList, setProjectList] = useState<ProjectInfo[]>([])
+  const listRef = useRef<FlatList<ChatItem>>(null)
+
+  const addMessage = useCallback((item: ChatItemData) => {
+    const msg = { ...item, id: nextId() } as ChatItem
+    setMessages((prev) => [...prev, msg])
+  }, [])
+
+  // send が useWebSocket より後に定義されるため ref 経由で参照する
+  const sendRef = useRef<(msg: WsMessage) => void>(() => {})
+  const sessionCreatedRef = useRef(false)
+
+  const handleMessage = useCallback((msg: WsMessage) => {
+    switch (msg.type) {
+      case 'auth_ok':
+        // 認証成功後にセッションを作成 / アタッチする
+        if (!sessionCreatedRef.current) {
+          sessionCreatedRef.current = true
+          if (sessionId) {
+            sendRef.current({ type: 'session_attach', sessionId })
+          } else {
+            const source: SessionSource = projectPath
+              ? { kind: 'claude', projectPath }
+              : { kind: 'claude' }
+            sendRef.current({ type: 'session_create', source })
+          }
+        }
+        break
+
+      case 'session_attached':
+        setCurrentSessionId(msg.sessionId)
+        setIsThinking(false)
+        setPendingPermission(null)
+        setSwitcherLoading(false)
+        setShowSwitcher(false)
+        if (msg.source?.kind !== 'claude') {
+          addMessage({ kind: 'system', content: `セッションに接続しました: ${msg.sessionId.slice(0, 8)}` })
+        }
+        break
+
+      case 'chat_ready':
+        addMessage({ kind: 'system', content: `claude 起動完了 (${msg.cwd})` })
+        break
+
+      case 'chat_assistant_message':
+        setIsThinking(false)
+        addMessage({ kind: 'assistant', content: msg.content })
+        break
+
+      case 'chat_tool_use':
+        addMessage({ kind: 'tool_use', toolName: msg.toolName, toolInput: msg.toolInput })
+        break
+
+      case 'chat_tool_result':
+        addMessage({ kind: 'tool_result', toolName: msg.toolName, content: msg.content, isError: msg.isError })
+        break
+
+      case 'chat_status':
+        if (msg.status === 'idle') setIsThinking(false)
+        break
+
+      case 'permission_request':
+        setPendingPermission({
+          requestId: msg.requestId,
+          toolName: msg.toolName,
+          details: msg.details,
+          requiresAlways: msg.requiresAlways,
+        })
+        break
+
+      case 'session_list_response':
+        setSessionList(msg.sessions)
+        setProjectList(msg.projects)
+        setSwitcherLoading(false)
+        setShowSwitcher(true)
+        break
+
+      case 'session_not_found':
+        addMessage({ kind: 'system', content: `セッションが見つかりません: ${msg.sessionId}` })
+        setSwitcherLoading(false)
+        setShowSwitcher(false)
+        break
+
+      case 'shell_exit':
+        addMessage({ kind: 'system', content: `セッションが終了しました (exit code: ${msg.exitCode})` })
+        setIsThinking(false)
+        break
+    }
+  }, [addMessage, sessionId, projectPath])
+
+  const { send, status } = useWebSocket({ ip, token, onMessage: handleMessage })
+  // sendRef を常に最新の send に向ける
+  sendRef.current = send
+
+  const handleSend = useCallback(() => {
+    const text = inputText.trim()
+    if (!text || status !== 'connected') return
+
+    addMessage({ kind: 'user', content: text })
+    setInputText('')
+    setIsThinking(true)
+    // PTY の stdin にテキストを送る（末尾改行でエンター）
+    send({ type: 'input', data: text + '\n' })
+  }, [inputText, status, addMessage, send])
+
+  const handlePermissionDecide = useCallback((requestId: string, decision: 'approve' | 'reject' | 'always') => {
+    setPendingPermission(null)
+    send({ type: 'permission_response', requestId, decision })
+  }, [send])
+
+  const handleOpenSwitcher = useCallback(() => {
+    setSwitcherLoading(true)
+    send({ type: 'session_list_request' })
+  }, [send])
+
+  const handleSwitchToSession = useCallback((sessionId: string) => {
+    setSwitcherLoading(true)
+    send({ type: 'session_attach', sessionId })
+  }, [send])
+
+  const handleCreateNewSession = useCallback((newProjectPath: string | null) => {
+    setSwitcherLoading(true)
+    const source: SessionSource = newProjectPath
+      ? { kind: 'claude', projectPath: newProjectPath }
+      : { kind: 'claude' }
+    send({ type: 'session_create', source })
+  }, [send])
+
+  const statusCfg = STATUS_CONFIG[status]
+  const showRetry = status === 'auth_error' || status === 'disconnected'
+  const canSend = status === 'connected' && inputText.trim().length > 0
+
+  // useWebSocket の onMessage を handleMessageWithSession に向ける
+  // useWebSocket 内部の onMessageRef.current が最新関数を参照するため、
+  // handleMessageWithSession を直接渡してもクロージャ問題はない
+  // ただし useWebSocket の引数は変わらないので再接続は起きない
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {/* ステータスバー */}
+      <View style={[styles.statusBar, { backgroundColor: statusCfg.bgColor }]} testID="status-bar">
+        <Text style={[styles.statusText, { color: statusCfg.color }]}>{statusCfg.label}</Text>
+        <View style={styles.statusActions}>
+          {status === 'connected' && (
+            <TouchableOpacity
+              testID="switcher-button"
+              style={styles.actionButton}
+              onPress={handleOpenSwitcher}
+              disabled={switcherLoading}
+            >
+              {switcherLoading
+                ? <ActivityIndicator size="small" color="#d4d4d4" />
+                : <Text style={styles.actionButtonText}>切替</Text>
+              }
+            </TouchableOpacity>
+          )}
+          {showRetry && (
+            <TouchableOpacity
+              testID="retry-button"
+              style={styles.actionButton}
+              onPress={() => {
+                sessionCreatedRef.current = false
+                setMessages([])
+                setIsThinking(false)
+                // useWebSocket は ip/token 変更で再接続するため、ここでは
+                // 親コンポーネントに委ねる。簡易再試行は切断→再接続で行う。
+                onDisconnect()
+              }}
+            >
+              <Text style={styles.actionButtonText}>再試行</Text>
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity testID="disconnect-button" style={styles.actionButton} onPress={onDisconnect}>
+            <Text style={styles.actionButtonText}>切断</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* チャットリスト */}
+      <FlatList
+        ref={listRef}
+        testID="chat-list"
+        data={messages}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
+        renderItem={({ item }) => <ChatBubble item={item} />}
+      />
+
+      {/* thinking インジケーター */}
+      {isThinking && (
+        <View testID="thinking-indicator" style={styles.thinkingRow}>
+          <ActivityIndicator size="small" color="#4ec9b0" />
+          <Text style={styles.thinkingText}>思考中...</Text>
+        </View>
+      )}
+
+      {/* 入力エリア */}
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <View style={styles.inputRow}>
+          <TextInput
+            testID="message-input"
+            style={styles.input}
+            value={inputText}
+            onChangeText={setInputText}
+            placeholder="メッセージを入力..."
+            placeholderTextColor="#666"
+            multiline
+            onSubmitEditing={handleSend}
+            blurOnSubmit={false}
+            editable={status === 'connected'}
+          />
+          <TouchableOpacity
+            testID="send-button"
+            style={[styles.sendButton, !canSend && styles.sendButtonDisabled]}
+            onPress={handleSend}
+            disabled={!canSend}
+          >
+            <Text style={styles.sendButtonText}>送信</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+
+      {/* 承認ボトムシート */}
+      <PermissionSheet request={pendingPermission} onDecide={handlePermissionDecide} />
+
+      {/* セッション切替モーダル */}
+      <SessionSwitcherModal
+        visible={showSwitcher}
+        loading={switcherLoading}
+        sessions={sessionList}
+        projects={projectList}
+        currentSessionId={currentSessionId}
+        onClose={() => setShowSwitcher(false)}
+        onSwitchSession={handleSwitchToSession}
+        onCreateSession={handleCreateNewSession}
+      />
+    </SafeAreaView>
+  )
+}
+
+// ─── チャットバブル ────────────────────────────────────────────────────────────
+
+function ChatBubble({ item }: { item: ChatItem }) {
+  switch (item.kind) {
+    case 'user':
+      return (
+        <View style={styles.userBubbleWrapper}>
+          <View style={styles.userBubble} testID="bubble-user">
+            <Text style={styles.userText}>{item.content}</Text>
+          </View>
+        </View>
+      )
+
+    case 'assistant':
+      return (
+        <View style={styles.assistantBubble} testID="bubble-assistant">
+          <Text style={styles.assistantText}>{item.content}</Text>
+        </View>
+      )
+
+    case 'tool_use':
+      return (
+        <View style={styles.toolCard} testID="bubble-tool-use">
+          <Text style={styles.toolName}>⚙ {item.toolName}</Text>
+          <Text style={styles.toolInput} numberOfLines={6}>{item.toolInput}</Text>
+        </View>
+      )
+
+    case 'tool_result':
+      return (
+        <View style={[styles.toolResultCard, item.isError && styles.toolResultError]} testID="bubble-tool-result">
+          <Text style={styles.toolResultText} numberOfLines={8}>{item.content}</Text>
+        </View>
+      )
+
+    case 'system':
+      return (
+        <View style={styles.systemRow} testID="bubble-system">
+          <Text style={styles.systemText}>{item.content}</Text>
+        </View>
+      )
+  }
+}
+
+// ─── スタイル ─────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#1e1e1e' },
+
+  // ステータスバー
+  statusBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  statusText: { fontSize: 12, fontWeight: '600' },
+  statusActions: { flexDirection: 'row', gap: 8, alignItems: 'center' },
+  actionButton: {
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 4,
+    minWidth: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actionButtonText: { color: '#d4d4d4', fontSize: 12 },
+
+  // チャットリスト
+  listContent: { padding: 12, gap: 8 },
+
+  // thinking
+  thinkingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+  },
+  thinkingText: { color: '#4ec9b0', fontSize: 12 },
+
+  // 入力エリア
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    padding: 8,
+    gap: 8,
+    borderTopWidth: 1,
+    borderTopColor: '#333',
+    backgroundColor: '#252526',
+  },
+  input: {
+    flex: 1,
+    color: '#d4d4d4',
+    backgroundColor: '#1e1e1e',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    maxHeight: 120,
+    borderWidth: 1,
+    borderColor: '#3c3c3c',
+  },
+  sendButton: {
+    backgroundColor: '#0e7afb',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sendButtonDisabled: { backgroundColor: '#333' },
+  sendButtonText: { color: '#fff', fontSize: 14, fontWeight: '600' },
+
+  // ユーザーバブル
+  userBubbleWrapper: { alignItems: 'flex-end' },
+  userBubble: {
+    backgroundColor: '#0e7afb',
+    borderRadius: 16,
+    borderBottomRightRadius: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    maxWidth: '80%',
+  },
+  userText: { color: '#fff', fontSize: 14 },
+
+  // アシスタントバブル
+  assistantBubble: {
+    backgroundColor: '#2d2d2d',
+    borderRadius: 16,
+    borderBottomLeftRadius: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    maxWidth: '90%',
+  },
+  assistantText: { color: '#d4d4d4', fontSize: 14, lineHeight: 20 },
+
+  // ツールカード
+  toolCard: {
+    backgroundColor: '#1f2d1f',
+    borderRadius: 8,
+    borderLeftWidth: 3,
+    borderLeftColor: '#4ec9b0',
+    padding: 10,
+  },
+  toolName: { color: '#4ec9b0', fontSize: 12, fontWeight: '700', marginBottom: 4 },
+  toolInput: {
+    color: '#9cdcfe',
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+
+  // ツール結果カード
+  toolResultCard: {
+    backgroundColor: '#252526',
+    borderRadius: 8,
+    borderLeftWidth: 3,
+    borderLeftColor: '#569cd6',
+    padding: 10,
+  },
+  toolResultError: { borderLeftColor: '#f44747', backgroundColor: '#2d1f1f' },
+  toolResultText: {
+    color: '#d4d4d4',
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+
+  // システムメッセージ
+  systemRow: { alignItems: 'center', paddingVertical: 4 },
+  systemText: { color: '#666', fontSize: 11 },
+})

--- a/packages/mobile/src/screens/SessionPickerScreen.tsx
+++ b/packages/mobile/src/screens/SessionPickerScreen.tsx
@@ -17,7 +17,7 @@ interface Props {
   /** プロジェクト選択時に呼ばれる。null は新規セッション（プロジェクトなし） */
   onSelectProject: (projectPath: string | null) => void
   /** 実行中セッションを選択したときに呼ばれる */
-  onAttachSession: (sessionId: string) => void
+  onAttachSession: (sessionId: string, source?: SessionSource) => void
   /** マルチプレクサセッション（tmux/screen/zellij）を選択したときに呼ばれる */
   onAttachMultiplexer: (source: SessionSource) => void
   onBack: () => void
@@ -91,10 +91,10 @@ export function SessionPickerScreen({ ip, token, onSelectProject, onAttachSessio
     onSelectProject(projectPath)
   }
 
-  const handleAttachSession = (sessionId: string) => {
+  const handleAttachSession = (session: SessionInfo) => {
     selectedRef.current = true
     wsRef.current?.close()
-    onAttachSession(sessionId)
+    onAttachSession(session.id, session.source)
   }
 
   const handleAttachMultiplexer = (mux: MultiplexerSessionInfo) => {
@@ -179,7 +179,7 @@ export function SessionPickerScreen({ ip, token, onSelectProject, onAttachSessio
               return (
                 <TouchableOpacity
                   style={styles.sessionRow}
-                  onPress={() => handleAttachSession(session.id)}
+                  onPress={() => handleAttachSession(session)}
                 >
                   <View
                     style={[

--- a/packages/mobile/src/screens/__tests__/SessionPickerScreen.test.tsx
+++ b/packages/mobile/src/screens/__tests__/SessionPickerScreen.test.tsx
@@ -112,7 +112,7 @@ describe('SessionPickerScreen', () => {
     await waitFor(() => expect(screen.getByText('myapp')).toBeTruthy())
     fireEvent.press(screen.getByText('myapp'))
 
-    expect(defaultProps.onAttachSession).toHaveBeenCalledWith('sid-abc')
+    expect(defaultProps.onAttachSession).toHaveBeenCalledWith('sid-abc', undefined)
     expect(mockWs.close).toHaveBeenCalled()
   })
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -45,6 +45,19 @@ export type WsMessage =
   | { type: 'permission_request'; requestId: string; toolName: string; details: string[]; requiresAlways: boolean }
   /** モバイルがデスクトップへ承認結果を返す */
   | { type: 'permission_response'; requestId: string; decision: 'approve' | 'reject' | 'always' }
+  // ── チャットUI用（--output-format stream-json パース結果） ──────────────────
+  /** claudeセッションが stream-json モードで起動完了した */
+  | { type: 'chat_ready'; sessionId: string; cwd: string }
+  /** ユーザー入力のエコーバック */
+  | { type: 'chat_user_message'; content: string }
+  /** アシスタントのテキスト応答 */
+  | { type: 'chat_assistant_message'; content: string }
+  /** ツール呼び出し */
+  | { type: 'chat_tool_use'; toolName: string; toolInput: string }
+  /** ツール実行結果 */
+  | { type: 'chat_tool_result'; toolName: string; content: string; isError: boolean }
+  /** claudeの処理状態変化 */
+  | { type: 'chat_status'; status: 'thinking' | 'idle' }
 
 export interface ProjectInfo {
   /** プロジェクトのフルパス */


### PR DESCRIPTION
## Summary
This PR adds a new chat-based UI for Claude sessions that parses structured JSON output from Claude's `--output-format stream-json` mode, enabling rich message rendering with tool use and results display.

## Key Changes

### New Chat Screen Component
- **ChatScreen.tsx**: New mobile screen component providing a chat interface for Claude sessions
  - Displays messages in conversation bubbles (user, assistant, tool use, tool results, system)
  - Real-time message streaming with thinking indicator
  - Session switching and creation via modal
  - Permission request handling via bottom sheet
  - Connection status bar with retry/disconnect actions
  - WebSocket-based communication with structured message types

### WebSocket Hook
- **useWebSocket.ts**: New hook managing WebSocket connection lifecycle
  - Handles authentication, reconnection with exponential backoff
  - Ping/pong keepalive mechanism
  - Connection status tracking (connecting, connected, reconnecting, auth_error, disconnected)
  - Prevents reconnection after auth errors or session exit

### Server-Side Stream-JSON Parsing
- **pty-server.ts**: Added parsing of Claude's structured JSON output
  - `parseAndSendChatMessages()`: Extracts NDJSON lines from PTY output and converts to WebSocket messages
  - `streamJsonEventToWsMessages()`: Transforms stream-json events (system, assistant, user, result) into chat message types
  - Spawns Claude with `--output-format stream-json` flag and increased terminal width (220 cols) to prevent JSON line wrapping
  - Maintains `jsonLineBuffer` in PtySession for handling partial lines across chunks

### Message Type Extensions
- **types.ts**: Added new WsMessage types for chat UI
  - `chat_ready`: Session initialization with cwd
  - `chat_assistant_message`: Assistant text responses
  - `chat_tool_use`: Tool invocation with name and input
  - `chat_tool_result`: Tool execution results with error flag
  - `chat_status`: Status updates (idle)

### App Navigation
- **App.tsx**: Updated routing to direct new Claude sessions to ChatScreen instead of TerminalScreen
  - New 'chat' screen type
  - `handleSelectProject()` routes to chat UI
  - `handleAttachSession()` checks session source to determine UI (chat for Claude, terminal for others)

### Test Updates
- **App.test.tsx**: Added fetch mock to prevent network errors during tests
- **SessionPickerScreen.test.tsx**: Updated test expectations for new callback signature
- **react-native.ts**: Added KeyboardAvoidingView mock for test compatibility

## Implementation Details
- Chat messages are accumulated in state with unique IDs and rendered via FlatList with auto-scroll
- Tool use and results are displayed as distinct card components with syntax highlighting
- Permission requests interrupt the chat flow and are handled via a bottom sheet modal
- Session switching is non-blocking with loading state
- The parser handles ANSI escape codes in JSON output via `stripAnsi()` utility
- Multiline text input with submit-on-enter and keyboard avoidance for iOS

https://claude.ai/code/session_01UmKTrD7YVzHwbbuaEAZcnn