### PR TITLE
chore: desktop・mobile のバージョンを 0.0.5 → 0.0.6 へインクリメント

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,3 +446,19 @@ export function buildTerminalHtml(wsUrl: string, token: string): string {
 - node-ptyはネイティブモジュールのためElectronのrebuildが必要（`electron-rebuild`）
 - iOS実機でのWebSocket接続にはATS（App Transport Security）の設定が必要な場合あり（Tailscale IPはプライベートIPのため通常は不要）
 - xterm.jsのFitAddonはWebViewのリサイズイベントで`fitAddon.fit()`を呼ぶ必要あり
+
+---
+
+## バージョン管理
+
+### バージョンをインクリメントする手順
+
+リリース時は以下の3ファイルのバージョンを同時に更新する。
+
+| ファイル | 対象パッケージ |
+|---|---|
+| `packages/desktop/package.json` | desktop |
+| `packages/mobile/package.json` | mobile |
+| `packages/mobile/app.json` | Expo（app store向け） |
+
+`packages/shared/package.json` は独立してバージョン管理するため、上記に含めない。

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/desktop",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "main": "./out/main/index.js",

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Remocoder",
     "slug": "remocoder",
     "scheme": "remocoder",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "orientation": "portrait",
     "userInterfaceStyle": "dark",
     "ios": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/mobile",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- `packages/desktop/package.json`、`packages/mobile/package.json`、`packages/mobile/app.json` のバージョンを `0.0.5` → `0.0.6` に更新
- `packages/shared/package.json` は独立管理のため対象外
- CLAUDE.md にバージョンインクリメント手順（対象ファイル一覧）を追記

## Test plan

- [ ] 各 package.json のバージョンが `0.0.6` になっていることを確認
- [ ] app.json のバージョンが `0.0.6` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)