### PR TITLE
docs: README を英語・日本語の別ファイルに分割して作成

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,139 @@
+# Remocoder
+
+デスクトップPC上で動作するClaude Codeのセッションを、モバイルデバイスからTailscale VPN経由でリモート操作するアプリケーションです。
+
+[English README](./README.md)
+
+---
+
+## 概要
+
+RemococderはデスクトップのClaude CodeセッションにiPhone/Androidからアクセスできるツールです。通信はTailscale VPN（WireGuard）で暗号化され、UUIDトークン認証によって保護されます。
+
+---
+
+## アーキテクチャ
+
+```
+モバイルアプリ (React Native / Expo)
+        │
+        │  WebSocket over Tailscale VPN
+        │
+デスクトップアプリ (Electron)
+        │
+        │  node-pty
+        │
+   Claude Code プロセス
+```
+
+| コンポーネント | 技術 |
+|--------------|------|
+| デスクトップアプリ | Electron + node-pty + ws |
+| モバイルアプリ | React Native (Expo) + WebView + xterm.js |
+| ターミナルUI | xterm.js（WebView内） |
+| 通信 | WebSocket over Tailscale VPN |
+| 認証 | UUIDトークン |
+
+---
+
+## リポジトリ構成
+
+```
+remocoder/
+├── packages/
+│   ├── shared/     # 共通型定義
+│   ├── desktop/    # Electronデスクトップアプリ
+│   ├── mobile/     # React Nativeモバイルアプリ (Expo)
+│   └── cli/        # 外部ターミナルのClaudeセッションを登録するCLIツール
+```
+
+---
+
+## 事前準備
+
+- [Node.js](https://nodejs.org/) v18+
+- [pnpm](https://pnpm.io/) v9+
+- [Tailscale](https://tailscale.com/) — デスクトップとモバイルの両方にインストール・ログイン済みであること
+- [Claude Code](https://claude.ai/code) — デスクトップにインストール済みであること
+
+---
+
+## セットアップ
+
+### 依存パッケージのインストール
+
+```bash
+pnpm install
+```
+
+### デスクトップアプリ
+
+```bash
+# 開発
+pnpm dev
+
+# 配布用ビルド
+pnpm --filter @remocoder/desktop dist:mac    # macOS
+pnpm --filter @remocoder/desktop dist:win    # Windows
+pnpm --filter @remocoder/desktop dist:linux  # Linux
+```
+
+アプリはシステムトレイに常駐し、TailscaleのIPアドレスとモバイルアプリに入力するトークンを表示します。
+
+### モバイルアプリ
+
+```bash
+# Expo開発サーバー起動
+pnpm mobile
+
+# iOSで起動
+pnpm mobile:ios
+
+# Androidで起動
+pnpm mobile:android
+```
+
+---
+
+## 使い方
+
+1. **デスクトップアプリを起動** するとシステムトレイに常駐します。
+2. トレイメニューに表示された **Tailscale IP** と **Auth Token** を確認します。
+3. **モバイルアプリを開き**、Connect画面にIPとトークンを入力します。
+4. **接続** をタップすると、デスクトップのClaude Codeに接続されたターミナルが開きます。
+
+---
+
+## セキュリティ
+
+- 通信はすべてTailscale VPN（WireGuard暗号化）内で行われます。
+- 接続ごとにUUIDトークン認証が必要です（5秒タイムアウト）。
+- WebSocketポートはTailscaleネットワーク内にのみ公開され、インターネットには公開されません。
+
+---
+
+## テスト
+
+```bash
+pnpm test
+```
+
+---
+
+## 技術スタック
+
+| レイヤー | パッケージ |
+|---------|----------|
+| デスクトップフレームワーク | Electron 30 |
+| PTY | node-pty |
+| WebSocketサーバー | ws |
+| モバイルフレームワーク | React Native 0.83 + Expo 55 |
+| ターミナルUI | xterm.js 5 + xterm-addon-fit |
+| ナビゲーション | expo-router |
+| ビルドシステム | Turborepo + pnpm workspaces |
+
+---
+
+## ライセンス
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,1 +1,139 @@
-# remocoder
+# Remocoder
+
+Remotely control Claude Code sessions running on your desktop PC from a mobile device via Tailscale VPN.
+
+[日本語版 README はこちら](./README.ja.md)
+
+---
+
+## Overview
+
+Remocoder lets you connect to Claude Code sessions on your desktop from your iPhone or Android device. Communication is secured by Tailscale VPN (WireGuard), with UUID token authentication on top.
+
+---
+
+## Architecture
+
+```
+Mobile App (React Native / Expo)
+        │
+        │  WebSocket over Tailscale VPN
+        │
+Desktop App (Electron)
+        │
+        │  node-pty
+        │
+   Claude Code process
+```
+
+| Component | Technology |
+|-----------|-----------|
+| Desktop app | Electron + node-pty + ws |
+| Mobile app | React Native (Expo) + WebView + xterm.js |
+| Terminal UI | xterm.js (inside WebView) |
+| Transport | WebSocket over Tailscale VPN |
+| Auth | UUID token |
+
+---
+
+## Repository Structure
+
+```
+remocoder/
+├── packages/
+│   ├── shared/     # Shared type definitions
+│   ├── desktop/    # Electron desktop app
+│   ├── mobile/     # React Native mobile app (Expo)
+│   └── cli/        # CLI tool to register external Claude sessions
+```
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v18+
+- [pnpm](https://pnpm.io/) v9+
+- [Tailscale](https://tailscale.com/) installed and logged in on both desktop and mobile devices
+- [Claude Code](https://claude.ai/code) installed on the desktop
+
+---
+
+## Getting Started
+
+### Install dependencies
+
+```bash
+pnpm install
+```
+
+### Desktop App
+
+```bash
+# Development
+pnpm dev
+
+# Build distributable
+pnpm --filter @remocoder/desktop dist:mac    # macOS
+pnpm --filter @remocoder/desktop dist:win    # Windows
+pnpm --filter @remocoder/desktop dist:linux  # Linux
+```
+
+The app runs in the system tray and displays your Tailscale IP and the auth token to enter in the mobile app.
+
+### Mobile App
+
+```bash
+# Start Expo dev server
+pnpm mobile
+
+# Run on iOS
+pnpm mobile:ios
+
+# Run on Android
+pnpm mobile:android
+```
+
+---
+
+## Usage
+
+1. **Start the desktop app** — it appears in the system tray.
+2. **Note the Tailscale IP and Auth Token** shown in the tray menu.
+3. **Open the mobile app** and enter the IP and token on the Connect screen.
+4. **Tap Connect** — a full xterm.js terminal opens, connected to Claude Code on your desktop.
+
+---
+
+## Security
+
+- All traffic runs inside the Tailscale VPN (WireGuard encryption).
+- A UUID token is required on each connection (5-second auth timeout).
+- The WebSocket port is only exposed within the Tailscale network, not to the public internet.
+
+---
+
+## Running Tests
+
+```bash
+pnpm test
+```
+
+---
+
+## Tech Stack
+
+| Layer | Package |
+|-------|---------|
+| Desktop framework | Electron 30 |
+| PTY | node-pty |
+| WebSocket server | ws |
+| Mobile framework | React Native 0.83 + Expo 55 |
+| Terminal UI | xterm.js 5 + xterm-addon-fit |
+| Navigation | expo-router |
+| Build system | Turborepo + pnpm workspaces |
+
+---
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- `README.md` を英語のみに整理し、アーキテクチャ・セットアップ・使い方・セキュリティ等を網羅した内容に刷新
- `README.ja.md` を新規作成（日本語版）
- 両ファイルに互いへのリンクを追加

## Test plan

- [ ] `README.md` の内容・リンクが正しく表示されることを確認
- [ ] `README.ja.md` の内容・リンクが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)