### PR TITLE
ci: desktop/mobile変更がない場合にCIジョブをスキップ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,30 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      desktop: ${{ steps.filter.outputs.desktop }}
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            desktop:
+              - 'packages/desktop/**'
+              - 'packages/shared/**'
+            mobile:
+              - 'packages/mobile/**'
+              - 'packages/shared/**'
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.mobile == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -19,14 +40,18 @@ jobs:
         run: pnpm --filter @remocoder/shared exec tsc --noEmit
 
       - name: Type check desktop
+        if: needs.changes.outputs.desktop == 'true'
         run: pnpm --filter @remocoder/desktop exec tsc --noEmit
 
       - name: Type check mobile
+        if: needs.changes.outputs.mobile == 'true'
         run: pnpm --filter @remocoder/mobile exec tsc --noEmit
 
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -5,10 +5,27 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      desktop: ${{ steps.filter.outputs.desktop }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            desktop:
+              - 'packages/desktop/**'
+              - 'packages/shared/**'
+
   build-desktop:
     name: Build Desktop macOS (DMG)
     runs-on: macos-latest
     environment: preview
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/eas-pr-build.yml
+++ b/.github/workflows/eas-pr-build.yml
@@ -5,10 +5,27 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            mobile:
+              - 'packages/mobile/**'
+              - 'packages/shared/**'
+
   build-android:
     name: Build Android (EAS Local)
     runs-on: ubuntu-latest
     environment: preview
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     permissions:
       contents: write
     steps:
@@ -45,6 +62,8 @@ jobs:
     name: Build iOS (EAS Local)
     runs-on: macos-26
     environment: preview
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     permissions:
       contents: write
     steps:
@@ -79,8 +98,8 @@ jobs:
     name: Notify Slack
     runs-on: ubuntu-latest
     environment: preview
-    needs: [build-android, build-ios]
-    if: always() && (needs.build-android.result == 'success' || needs.build-ios.result == 'success')
+    needs: [changes, build-android, build-ios]
+    if: needs.changes.outputs.mobile == 'true' && always() && (needs.build-android.result == 'success' || needs.build-ios.result == 'success')
     steps:
       - name: Build Slack payload
         id: payload


### PR DESCRIPTION
closes #97

## Summary

`dorny/paths-filter@v3` を使って変更ファイルを検知し、関連パッケージに変更がない場合はビルド・テストジョブをスキップする。

| 変更パス | 実行されるジョブ |
|---|---|
| `packages/desktop/**` / `packages/shared/**` | Type Check (desktop)、Test、Desktop PR Build |
| `packages/mobile/**` / `packages/shared/**` | Type Check (mobile)、EAS Build (Android/iOS)、Slack通知 |

## 変更ファイル

- `.github/workflows/ci.yml` — `changes` ジョブを追加、`typecheck` / `test` に `if` 条件を追加
- `.github/workflows/desktop-pr-build.yml` — `changes` ジョブを追加、`build-desktop` に `if` 条件を追加
- `.github/workflows/eas-pr-build.yml` — `changes` ジョブを追加、`build-android` / `build-ios` / `notify-slack` に `if` 条件を追加

## Test plan

- [ ] desktop のみ変更するPRで EAS ビルドがスキップされることを確認
- [ ] mobile のみ変更するPRで Desktop ビルドがスキップされることを確認
- [ ] `packages/shared` の変更で両方のジョブが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)