### PR TITLE
ci: packages/cliの変更検知をCIに追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       desktop: ${{ steps.filter.outputs.desktop }}
       mobile: ${{ steps.filter.outputs.mobile }}
+      cli: ${{ steps.filter.outputs.cli }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -25,12 +26,15 @@ jobs:
             mobile:
               - 'packages/mobile/**'
               - 'packages/shared/**'
+            cli:
+              - 'packages/cli/**'
+              - 'packages/shared/**'
 
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.mobile == 'true'
+    if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.cli == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -47,11 +51,15 @@ jobs:
         if: needs.changes.outputs.mobile == 'true'
         run: pnpm --filter @remocoder/mobile exec tsc --noEmit
 
+      - name: Type check cli
+        if: needs.changes.outputs.cli == 'true'
+        run: pnpm --filter @remocoder/cli exec tsc --noEmit
+
   test:
     name: Test
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.desktop == 'true'
+    if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cli == 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- `packages/cli` がパスフィルターに含まれておらず、cli変更時にtypecheck・testがスキップされていた問題を修正
- `changes` ジョブに `cli` フィルター（`packages/cli/**`, `packages/shared/**`）を追加
- `typecheck` ジョブに "Type check cli" ステップを追加
- `test` ジョブの実行条件に `cli` 変更を追加

## Test plan

- [ ] `packages/cli` を変更したPRでtypecheck・testが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)