### PR TITLE
chore: unify RemoCoder display name

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# Remocoder
+# RemoCoder
 
 デスクトップPC上で動作するClaude Codeのセッションを、モバイルデバイスからTailscale VPN経由でリモート操作するアプリケーションです。
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Remocoder
+# RemoCoder
 
 Remotely control Claude Code sessions running on your desktop PC from a mobile device via Tailscale VPN.
 
@@ -8,7 +8,7 @@ Remotely control Claude Code sessions running on your desktop PC from a mobile d
 
 ## Overview
 
-Remocoder lets you connect to Claude Code sessions on your desktop from your iPhone or Android device. Communication is secured by Tailscale VPN (WireGuard), with UUID token authentication on top.
+RemoCoder lets you connect to Claude Code sessions on your desktop from your iPhone or Android device. Communication is secured by Tailscale VPN (WireGuard), with UUID token authentication on top.
 
 ---
 

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>プライバシーポリシー - Remocoder</title>
+  <title>プライバシーポリシー - RemoCoder</title>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -21,7 +21,7 @@
   <h1>プライバシーポリシー</h1>
   <p>最終更新日：2026年3月13日</p>
 
-  <p>本プライバシーポリシーは、Remocoder（以下「本アプリ」）における個人情報の取り扱いについて説明します。</p>
+  <p>本プライバシーポリシーは、RemoCoder（以下「本アプリ」）における個人情報の取り扱いについて説明します。</p>
 
   <h2>収集する情報</h2>
   <p>本アプリは以下の権限を使用します：</p>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@remocoder/cli",
   "version": "0.0.1",
   "private": true,
-  "description": "外部ターミナルのclaudeセッションをRemococderに登録するCLIツール",
+  "description": "外部ターミナルのclaudeセッションをRemoCoderに登録するCLIツール",
   "type": "module",
   "bin": {
     "remocoder-claude": "./dist/index.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,10 +2,10 @@
 /**
  * remocoder-claude
  *
- * 外部ターミナルで起動したclaudeセッションをRemococderに登録するCLIツール。
+ * 外部ターミナルで起動したclaudeセッションをRemoCoderに登録するCLIツール。
  * このコマンドはclaudeの代わりに使用する：
  *
- *   remocoder-claude           # claudeを起動してRemococderに登録
+ *   remocoder-claude           # claudeを起動してRemoCoderに登録
  *   remocoder-claude --resume  # 再開フラグ付きで起動
  *
  * 初回セットアップ：
@@ -25,11 +25,11 @@ import type { WsMessage } from '@remocoder/shared'
 function getTokenFilePath(): string {
   const os = platform()
   if (os === 'darwin') {
-    return join(homedir(), 'Library', 'Application Support', 'Remocoder', 'auth-token.json')
+    return join(homedir(), 'Library', 'Application Support', 'RemoCoder', 'auth-token.json')
   } else if (os === 'win32') {
-    return join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), 'Remocoder', 'auth-token.json')
+    return join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), 'RemoCoder', 'auth-token.json')
   } else {
-    return join(homedir(), '.config', 'Remocoder', 'auth-token.json')
+    return join(homedir(), '.config', 'RemoCoder', 'auth-token.json')
   }
 }
 
@@ -47,7 +47,7 @@ function resolveToken(): string {
   }
 
   console.error(`[remocoder-claude] トークンが見つかりません。`)
-  console.error(`  Remococderデスクトップアプリが起動しているか確認してください。`)
+  console.error(`  RemoCoderデスクトップアプリが起動しているか確認してください。`)
   console.error(`  または環境変数 REMOCODER_TOKEN にトークンを設定してください。`)
   process.exit(1)
 }
@@ -60,7 +60,7 @@ const claudeArgs = process.argv.slice(2)
 
 const token = resolveToken()
 
-console.log(`[remocoder-claude] Remococderに接続中 (${WS_URL})...`)
+console.log(`[remocoder-claude] RemoCoderに接続中 (${WS_URL})...`)
 
 const ws = new WebSocket(WS_URL)
 let shell: pty.IPty | null = null
@@ -110,7 +110,7 @@ ws.on('message', (raw) => {
       cwd: process.cwd(),
     })
 
-    // PTY出力 → ローカル端末 + Remococderサーバーへ転送
+    // PTY出力 → ローカル端末 + RemoCoderサーバーへ転送
     shell.onData((data) => {
       process.stdout.write(data)
       safeSend({ type: 'output', data })
@@ -155,7 +155,7 @@ ws.on('message', (raw) => {
 
 ws.on('error', (err) => {
   console.error(`[remocoder-claude] 接続エラー: ${err.message}`)
-  console.error(`  Remococderデスクトップアプリが起動しているか確認してください。`)
+  console.error(`  RemoCoderデスクトップアプリが起動しているか確認してください。`)
   process.exit(1)
 })
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -17,8 +17,8 @@
   },
   "build": {
     "appId": "com.remocoder.desktop",
-    "productName": "Remocoder",
-    "copyright": "Copyright © 2025 Remocoder",
+    "productName": "RemoCoder",
+    "copyright": "Copyright © 2025 RemoCoder",
     "directories": {
       "output": "dist"
     },

--- a/packages/mobile/app.config.js
+++ b/packages/mobile/app.config.js
@@ -41,7 +41,7 @@ module.exports = ({ config }) => {
 
   const variantConfig = IS_DEV
     ? {
-        name: 'Remocoder Dev',
+        name: 'RemoCoder Dev',
         icon: './assets/icon-dev.png',
         androidIcon: './assets/icon-android-dev.png',
         bundleIdentifier: 'com.remocoder.app.dev',

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Remocoder",
+    "name": "RemoCoder",
     "slug": "remocoder",
     "scheme": "remocoder",
     "version": "0.0.13",

--- a/packages/mobile/src/screens/ConnectScreen.tsx
+++ b/packages/mobile/src/screens/ConnectScreen.tsx
@@ -227,7 +227,7 @@ export function ConnectScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Remocoder</Text>
+      <Text style={styles.title}>RemoCoder</Text>
 
       {profiles.length === 0 ? (
         <View style={styles.emptyState}>


### PR DESCRIPTION
## Summary
- unify user-facing app name references to RemoCoder
- fix Remococder typos in CLI-facing text and metadata
- keep technical identifiers such as remocoder unchanged

## Testing
- pnpm --filter @remocoder/cli test
- pnpm --filter @remocoder/desktop test
- pnpm --filter @remocoder/mobile test