### PR TITLE
fix(mobile): PermissionSheet の表示安定性を改善

### DIFF
--- a/packages/mobile/src/components/PermissionSheet.tsx
+++ b/packages/mobile/src/components/PermissionSheet.tsx
@@ -151,7 +151,6 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: -4 },
     shadowOpacity: 0.4,
     shadowRadius: 8,
-    zIndex: 10,
   },
   progressBar: {
     height: 3,

--- a/packages/mobile/src/components/PermissionSheet.tsx
+++ b/packages/mobile/src/components/PermissionSheet.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import { Animated, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useKeyboardHeight } from '../hooks/useKeyboardHeight'
 
 export interface PermissionRequest {
   requestId: string
@@ -48,7 +47,6 @@ function isDangerous(details: string[]): boolean {
 
 export function PermissionSheet({ request, onDecide }: Props) {
   const { bottom: bottomInset } = useSafeAreaInsets()
-  const keyboardHeight = useKeyboardHeight()
   const slideAnim = useRef(new Animated.Value(300)).current
   const progressAnim = useRef(new Animated.Value(1)).current
 
@@ -73,14 +71,13 @@ export function PermissionSheet({ request, onDecide }: Props) {
   if (!request) return null
   const decide = (decision: 'approve' | 'reject' | 'always') => onDecide(request.requestId, decision)
 
-  const sheetPaddingBottom = keyboardHeight > 0 ? 24 : 24 + bottomInset
+  const sheetPaddingBottom = 24 + bottomInset
 
   return (
     <Animated.View
       style={[
         styles.sheet,
-        // キーボード表示中は bottom をキーボード高さ分オフセットして隠れを防ぐ
-        { bottom: keyboardHeight, paddingBottom: sheetPaddingBottom, transform: [{ translateY: slideAnim }] },
+        { paddingBottom: sheetPaddingBottom, transform: [{ translateY: slideAnim }] },
       ]}
     >
       {/* Progress bar */}
@@ -142,10 +139,6 @@ export function PermissionSheet({ request, onDecide }: Props) {
 
 const styles = StyleSheet.create({
   sheet: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
     backgroundColor: '#0d1117',
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
@@ -158,6 +151,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: -4 },
     shadowOpacity: 0.4,
     shadowRadius: 8,
+    zIndex: 10,
   },
   progressBar: {
     height: 3,

--- a/packages/mobile/src/screens/TerminalScreen.tsx
+++ b/packages/mobile/src/screens/TerminalScreen.tsx
@@ -180,7 +180,12 @@ export function TerminalScreen() {
       <KeyboardToolbar webViewRef={webViewRef} />
 
       {/* 承認ボトムシート */}
-      <PermissionSheet request={pendingPermission} onDecide={handlePermissionDecide} />
+      <View
+        pointerEvents="box-none"
+        style={[styles.permissionOverlay, { bottom: keyboardHeight }]}
+      >
+        <PermissionSheet request={pendingPermission} onDecide={handlePermissionDecide} />
+      </View>
     </SafeAreaView>
   )
 }
@@ -216,5 +221,13 @@ const styles = StyleSheet.create({
   actionButtonText: {
     color: '#d4d4d4',
     fontSize: 12,
+  },
+  permissionOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 10,
+    elevation: 10,
   },
 })

--- a/packages/mobile/src/screens/TerminalScreen.tsx
+++ b/packages/mobile/src/screens/TerminalScreen.tsx
@@ -181,6 +181,7 @@ export function TerminalScreen() {
 
       {/* 承認ボトムシート */}
       <View
+        testID="permission-overlay"
         pointerEvents="box-none"
         style={[styles.permissionOverlay, { bottom: keyboardHeight }]}
       >

--- a/packages/mobile/src/screens/TerminalScreen.tsx
+++ b/packages/mobile/src/screens/TerminalScreen.tsx
@@ -227,7 +227,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    bottom: 0,
+    // Keep the permission sheet above the WebView/toolbar stack on mobile.
     zIndex: 10,
     elevation: 10,
   },

--- a/packages/mobile/src/screens/__tests__/TerminalScreen.test.tsx
+++ b/packages/mobile/src/screens/__tests__/TerminalScreen.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, fireEvent, act } from '@testing-library/react-native'
 import { TerminalScreen } from '../TerminalScreen'
 import { injectJavaScriptMock } from '../../__mocks__/react-native-webview'
 import { useLocalSearchParams, mockRouterBack } from '../../__mocks__/expo-router'
+import { useKeyboardHeight } from '../../hooks/useKeyboardHeight'
+
+jest.mock('../../hooks/useKeyboardHeight', () => ({
+  useKeyboardHeight: jest.fn(() => 0),
+}))
 
 describe('TerminalScreen', () => {
   // WebView から onMessage を発火するヘルパー
@@ -16,6 +21,7 @@ describe('TerminalScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     injectJavaScriptMock.mockClear()
+    ;(useKeyboardHeight as jest.Mock).mockReturnValue(0)
     ;(useLocalSearchParams as jest.Mock).mockReturnValue({
       ip: '100.64.0.1',
       token: 'test-token',
@@ -101,6 +107,23 @@ describe('TerminalScreen', () => {
   })
 
   describe('PermissionSheet', () => {
+    it('キーボード表示中でも PermissionSheet が表示される', () => {
+      ;(useKeyboardHeight as jest.Mock).mockReturnValue(180)
+
+      render(<TerminalScreen />)
+      sendFromWebView({
+        type: 'permission_request',
+        requestId: 'req-keyboard',
+        toolName: 'Bash',
+        details: ['echo hello'],
+        requiresAlways: false,
+        createdAt: Date.now(),
+      })
+
+      expect(screen.getByText('Permission Request')).toBeTruthy()
+      expect(screen.getByText('Allow')).toBeTruthy()
+    })
+
     it('permission_request を受信すると PermissionSheet が表示される', () => {
       render(<TerminalScreen />)
       sendFromWebView({

--- a/packages/mobile/src/screens/__tests__/TerminalScreen.test.tsx
+++ b/packages/mobile/src/screens/__tests__/TerminalScreen.test.tsx
@@ -120,6 +120,12 @@ describe('TerminalScreen', () => {
         createdAt: Date.now(),
       })
 
+      const overlay = screen.getByTestId('permission-overlay')
+      expect(overlay.props.style).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ bottom: 180 }),
+        ]),
+      )
       expect(screen.getByText('Permission Request')).toBeTruthy()
       expect(screen.getByText('Allow')).toBeTruthy()
     })
@@ -132,6 +138,7 @@ describe('TerminalScreen', () => {
         toolName: 'Bash',
         details: ['rm -rf /tmp/test'],
         requiresAlways: true,
+        createdAt: Date.now(),
       })
 
       expect(screen.getByText('Permission Request')).toBeTruthy()
@@ -150,6 +157,7 @@ describe('TerminalScreen', () => {
         toolName: 'Write',
         details: ['/tmp/file.ts'],
         requiresAlways: false,
+        createdAt: Date.now(),
       })
 
       expect(screen.getByText('Allow')).toBeTruthy()
@@ -165,6 +173,7 @@ describe('TerminalScreen', () => {
         toolName: 'Bash',
         details: [],
         requiresAlways: false,
+        createdAt: Date.now(),
       })
 
       fireEvent.press(screen.getByText('Allow'))
@@ -183,6 +192,7 @@ describe('TerminalScreen', () => {
         toolName: 'Bash',
         details: [],
         requiresAlways: false,
+        createdAt: Date.now(),
       })
 
       fireEvent.press(screen.getByText('Deny'))
@@ -201,6 +211,7 @@ describe('TerminalScreen', () => {
         toolName: 'Bash',
         details: [],
         requiresAlways: true,
+        createdAt: Date.now(),
       })
 
       fireEvent.press(screen.getByText('Always Allow'))


### PR DESCRIPTION
## 概要

キーボード表示時に `PermissionSheet` が正しく位置調整されなかった問題を修正。

## 問題の原因

`PermissionSheet` 自身が `position: absolute` と `bottom: keyboardHeight` を保持していたため、`SafeAreaView` の座標系と食い違いが生じ、キーボード表示中にシートの位置がずれる・隠れるケースがあった。

## 変更内容

### `PermissionSheet.tsx`
- `position: absolute / left: 0 / right: 0 / bottom: 0` を除去し、純粋なコンテンツコンポーネントに変更
- `useKeyboardHeight` 依存を除去
- `sheetPaddingBottom` の計算をキーボード表示有無の分岐から `24 + bottomInset` 固定に統一
- 不要な `zIndex: 10` を除去

### `TerminalScreen.tsx`
- `permissionOverlay` ラッパー `View` を追加し、`position: absolute` と `bottom: keyboardHeight` をここで一元管理
- `pointerEvents="box-none"` を設定し、背後の WebView / KeyboardToolbar へのタッチを妨げないように
- `zIndex: 10` に WebView / toolbar スタックの上に表示するための意図をコメントで明示

### `TerminalScreen.test.tsx`
- `useKeyboardHeight` のモック追加
- キーボード表示中でも `PermissionSheet` が表示されることを確認するテストを追加
- `permissionOverlay` の `bottom` スタイル値が `keyboardHeight` と一致することをアサート
- 既存テスト全件に `createdAt` フィールドを補完

## テスト

全 125 テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)