### PR TITLE
feat(docs): ホームページを追加 (#114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .DS_Store
 packages/desktop/out/
 *.p12
+.superpowers/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,946 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Remocoder — 外出先から、デスクトップの Claude Code をそのまま操作</title>
+  <meta name="description" content="Tailscale 経由で安全接続。iPhone / Android から既存セッションにも再接続できるリモートターミナルアプリ。">
+  <meta property="og:title" content="Remocoder — 外出先から、デスクトップの Claude Code をそのまま操作">
+  <meta property="og:description" content="Tailscale 経由で安全接続。iPhone / Android から既存セッションにも再接続できるリモートターミナルアプリ。">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Remocoder — 外出先から、デスクトップの Claude Code をそのまま操作">
+  <meta name="twitter:description" content="Tailscale 経由で安全接続。iPhone / Android から既存セッションにも再接続できるリモートターミナルアプリ。">
+  <link rel="icon" href="favicon.ico" type="image/x-icon">
+  <style>
+    :root {
+      --bg: #0d0d0d;
+      --bg-2: #141414;
+      --bg-3: #1a1a1a;
+      --border: #2a2a2a;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --text-dim: #555;
+      --accent: #7c6aff;
+      --accent-dim: #3d3380;
+      --green: #3ddc84;
+      --green-dim: #1a4a34;
+      --font-mono: "Menlo", "Monaco", "Consolas", "Courier New", monospace;
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--font-sans);
+      line-height: 1.7;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a { color: inherit; text-decoration: none; }
+
+    /* ─── NAV ─── */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 40px;
+      background: rgba(13,13,13,0.85);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-logo {
+      font-family: var(--font-mono);
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: -0.02em;
+    }
+    .nav-logo span { color: var(--accent); }
+    .nav-links {
+      display: flex;
+      gap: 32px;
+      list-style: none;
+      font-size: 0.875rem;
+      color: var(--text-muted);
+    }
+    .nav-links a:hover { color: var(--text); }
+
+    /* ─── SECTIONS ─── */
+    section { padding: 96px 40px; max-width: 1100px; margin: 0 auto; }
+
+    .section-label {
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--accent);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: 16px;
+    }
+
+    h1, h2, h3 { line-height: 1.2; letter-spacing: -0.02em; }
+
+    /* ─── HERO ─── */
+    #hero {
+      padding-top: 120px;
+      padding-bottom: 120px;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 64px;
+      align-items: center;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+    .hero-eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      background: var(--accent-dim);
+      border: 1px solid var(--accent);
+      border-radius: 100px;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--accent);
+      margin-bottom: 28px;
+    }
+    .hero-eyebrow::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent);
+      animation: pulse 2s infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+    h1 {
+      font-size: clamp(2rem, 4vw, 3rem);
+      font-weight: 700;
+      color: var(--text);
+      margin-bottom: 20px;
+    }
+    h1 em {
+      font-style: normal;
+      color: var(--accent);
+    }
+    .hero-sub {
+      font-size: 1.1rem;
+      color: var(--text-muted);
+      margin-bottom: 40px;
+      max-width: 460px;
+    }
+    .hero-ctas {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .btn-primary {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 24px;
+      background: var(--accent);
+      color: #fff;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      transition: opacity 0.2s;
+    }
+    .btn-primary:hover { opacity: 0.85; }
+    .btn-secondary {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 24px;
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      border-radius: 8px;
+      font-size: 0.9rem;
+      font-weight: 500;
+      transition: border-color 0.2s, color 0.2s;
+    }
+    .btn-secondary:hover { border-color: var(--accent); color: var(--text); }
+
+    /* Terminal mockup */
+    .hero-terminal {
+      background: var(--bg-3);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 32px 80px rgba(0,0,0,0.6);
+    }
+    .terminal-topbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      background: var(--bg-2);
+      border-bottom: 1px solid var(--border);
+    }
+    .dot { width: 12px; height: 12px; border-radius: 50%; }
+    .dot-red { background: #ff5f57; }
+    .dot-yellow { background: #febc2e; }
+    .dot-green { background: #28c840; }
+    .terminal-title {
+      flex: 1;
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dim);
+    }
+    .terminal-body {
+      padding: 20px;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      line-height: 1.8;
+      min-height: 240px;
+    }
+    .t-prompt { color: var(--green); }
+    .t-cmd { color: var(--text); }
+    .t-out { color: var(--text-muted); }
+    .t-acc { color: var(--accent); }
+    .t-modified { color: #ff8c69; }
+    .t-cursor {
+      display: inline-block;
+      width: 8px;
+      height: 14px;
+      background: var(--accent);
+      animation: blink 1s step-end infinite;
+      vertical-align: text-bottom;
+    }
+    @keyframes blink {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0; }
+    }
+    .conn-badge {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      background: var(--green-dim);
+      border: 1px solid var(--green);
+      border-radius: 6px;
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      color: var(--green);
+      margin-bottom: 12px;
+    }
+    .conn-badge::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--green);
+    }
+
+    /* ─── SHARED SECTION HEADING ─── */
+    #features h2,
+    #get-started h2,
+    #main-features h2,
+    #target-users h2 {
+      font-size: clamp(1.5rem, 3vw, 2.2rem);
+      margin-bottom: 56px;
+    }
+    #faq h2 {
+      font-size: clamp(1.5rem, 3vw, 2.2rem);
+      margin-bottom: 48px;
+    }
+    #how-it-works h2,
+    #security h2 {
+      font-size: clamp(1.5rem, 3vw, 2.2rem);
+      margin-bottom: 16px;
+    }
+
+    /* ─── SHARED CARD BASE ─── */
+    .card {
+      background: var(--bg-2);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+    }
+
+    /* ─── DISABLED BUTTON ─── */
+    [aria-disabled="true"] {
+      opacity: 0.45;
+      cursor: default;
+    }
+
+    /* ─── WHAT YOU CAN DO ─── */
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+    .feature-card {
+      padding: 28px;
+      transition: border-color 0.2s;
+    }
+    .feature-card:hover { border-color: var(--accent); }
+    .feature-icon {
+      width: 44px;
+      height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--accent-dim);
+      border-radius: 10px;
+      margin-bottom: 16px;
+      font-size: 1.3rem;
+    }
+    .feature-card h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+    .feature-card p {
+      font-size: 0.875rem;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+
+    /* ─── WIDE SECTION (full-bleed with inner wrapper) ─── */
+    .wide-section {
+      background: var(--bg-2);
+      max-width: 100%;
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      padding: 96px 40px;
+    }
+    .wide-section > .inner { max-width: 1100px; margin: 0 auto; }
+    .section-sub {
+      font-size: 1rem;
+      color: var(--text-muted);
+      max-width: 560px;
+    }
+
+    /* ─── HOW IT WORKS ─── */
+    #how-it-works .section-sub { margin-bottom: 56px; }
+    .arch-diagram {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .arch-box {
+      padding: 20px 28px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      text-align: center;
+      background: var(--bg-3);
+      min-width: 160px;
+    }
+    .arch-box .arch-icon { font-size: 2rem; margin-bottom: 8px; }
+    .arch-box .arch-label {
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+    .arch-box .arch-desc {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 4px;
+    }
+    .arch-arrow {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 0 8px;
+    }
+    .arch-arrow .arrow-line {
+      width: 60px;
+      height: 1px;
+      background: linear-gradient(to right, var(--accent), var(--green));
+    }
+    .arch-arrow .arrow-label {
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      color: var(--text-dim);
+    }
+    .security-note {
+      margin-top: 40px;
+      padding: 20px 24px;
+      background: var(--green-dim);
+      border: 1px solid var(--green);
+      border-radius: 10px;
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      font-size: 0.875rem;
+      color: var(--text);
+    }
+    .security-note .icon { font-size: 1.2rem; flex-shrink: 0; margin-top: 1px; }
+
+    /* ─── 3 STEPS ─── */
+    .steps {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 32px;
+      position: relative;
+    }
+    .steps::before {
+      content: "";
+      position: absolute;
+      top: 26px;
+      left: calc(16.66% + 16px);
+      right: calc(16.66% + 16px);
+      height: 1px;
+      background: linear-gradient(to right, var(--accent), var(--green));
+    }
+    .step {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .step-num {
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
+      background: var(--accent-dim);
+      border: 1px solid var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-mono);
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: var(--accent);
+      position: relative;
+      z-index: 1;
+    }
+    .step h3 {
+      font-size: 1rem;
+      font-weight: 600;
+    }
+    .step p {
+      font-size: 0.875rem;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+
+    /* ─── MAIN FEATURES ─── */
+    .feat-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+    }
+    .feat-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+      padding: 20px;
+      border-radius: 10px;
+    }
+    .feat-item .fi-icon {
+      font-size: 1.4rem;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+    .feat-item h4 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .feat-item p {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+
+    /* ─── SECURITY ─── */
+    #security .section-sub { margin-bottom: 48px; }
+    .security-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+    }
+    .security-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+      padding: 20px 24px;
+      background: var(--bg-3);
+      border-radius: 10px;
+    }
+    .security-item .si-icon {
+      font-size: 1.3rem;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+    .security-item h4 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .security-item p {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+
+    /* ─── TARGET USERS ─── */
+    .user-cards {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+    .user-card {
+      padding: 28px;
+    }
+    .user-card .uc-icon { font-size: 1.8rem; margin-bottom: 16px; }
+    .user-card h3 {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin-bottom: 10px;
+    }
+    .user-card p {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+
+    /* ─── FAQ ─── */
+    .faq-list { max-width: 720px; }
+    details {
+      border-bottom: 1px solid var(--border);
+    }
+    details:first-of-type { border-top: 1px solid var(--border); }
+    summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 0;
+      cursor: pointer;
+      font-size: 0.95rem;
+      font-weight: 500;
+      list-style: none;
+      user-select: none;
+    }
+    summary::-webkit-details-marker { display: none; }
+    summary::after {
+      content: "+";
+      font-size: 1.2rem;
+      color: var(--text-muted);
+      transition: transform 0.2s;
+      flex-shrink: 0;
+    }
+    details[open] summary::after {
+      transform: rotate(45deg);
+    }
+    .faq-answer {
+      padding-bottom: 20px;
+      font-size: 0.875rem;
+      color: var(--text-muted);
+      line-height: 1.7;
+    }
+
+    /* ─── FINAL CTA ─── */
+    #cta {
+      text-align: center;
+      padding: 120px 40px;
+    }
+    #cta h2 {
+      font-size: clamp(1.8rem, 4vw, 3rem);
+      margin-bottom: 16px;
+    }
+    #cta h2 em {
+      font-style: normal;
+      color: var(--accent);
+    }
+    #cta p {
+      font-size: 1.05rem;
+      color: var(--text-muted);
+      margin-bottom: 40px;
+    }
+    #cta .cta-btns {
+      display: flex;
+      gap: 16px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    /* ─── FOOTER ─── */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 32px 40px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 0.8rem;
+      color: var(--text-dim);
+    }
+    footer a { color: var(--text-dim); }
+    footer a:hover { color: var(--text-muted); }
+
+    /* ─── RESPONSIVE ─── */
+    @media (max-width: 768px) {
+      nav { padding: 14px 20px; }
+      .nav-links { display: none; }
+      #hero { grid-template-columns: 1fr; padding: 80px 20px; gap: 48px; }
+      section { padding: 72px 20px; }
+      #how-it-works, #security { padding: 72px 20px; }
+      .features-grid, .steps, .user-cards { grid-template-columns: 1fr; }
+      .steps::before { display: none; }
+      .feat-grid, .security-grid { grid-template-columns: 1fr; }
+      .arch-diagram { flex-direction: column; }
+      .arch-arrow { transform: rotate(90deg); }
+      footer { flex-direction: column; gap: 16px; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ─── NAV ─── -->
+<nav aria-label="メインナビゲーション">
+  <a href="#" class="nav-logo">remo<span>coder</span></a>
+  <ul class="nav-links" role="list">
+    <li><a href="#features">機能</a></li>
+    <li><a href="#how-it-works">仕組み</a></li>
+    <li><a href="#get-started">使い方</a></li>
+    <li><a href="#security">セキュリティ</a></li>
+    <li><a href="#faq">FAQ</a></li>
+  </ul>
+</nav>
+
+<!-- ─── 1. HERO ─── -->
+<section id="hero">
+  <div class="hero-left">
+    <div class="hero-eyebrow">Tailscale VPN 経由で安全接続</div>
+    <h1>外出先から、デスクトップの<em> Claude Code </em>をそのまま操作</h1>
+    <p class="hero-sub">
+      iPhone / Android からデスクトップ上の Claude Code セッションに接続。
+      既存セッションへの再接続も、新規セッション開始も、ポケットから。
+    </p>
+    <div class="hero-ctas">
+      <a href="#get-started" class="btn-primary">使い方を見る →</a>
+      <a href="#" class="btn-secondary" aria-disabled="true" tabindex="-1">ダウンロード（準備中）</a>
+    </div>
+  </div>
+  <div class="hero-right">
+    <div class="hero-terminal">
+      <div class="terminal-topbar" aria-hidden="true">
+        <div class="dot dot-red"></div>
+        <div class="dot dot-yellow"></div>
+        <div class="dot dot-green"></div>
+        <div class="terminal-title">remocoder — claude</div>
+      </div>
+      <div class="terminal-body">
+        <div class="conn-badge">接続済み — 100.x.x.x:8080</div>
+        <div><span class="t-prompt">❯ </span><span class="t-cmd">claude</span></div>
+        <div class="t-out">Claude Code v1.x.x</div>
+        <div class="t-out">Working in <span class="t-acc">~/projects/myapp</span></div>
+        <br>
+        <div><span class="t-prompt">❯ </span><span class="t-cmd">git status</span></div>
+        <div class="t-out">On branch feat/new-api</div>
+        <div class="t-out">Changes not staged for commit:</div>
+        <div class="t-out">&nbsp;&nbsp;<span class="t-modified">modified: src/api.ts</span></div>
+        <br>
+        <div><span class="t-prompt">❯ </span><span class="t-cursor"></span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── 2. WHAT YOU CAN DO ─── -->
+<section id="features">
+  <div class="section-label">何ができるか</div>
+  <h2>Claude Code をポケットに入れて持ち歩く</h2>
+  <div class="features-grid">
+    <div class="feature-card card">
+      <div class="feature-icon">📱</div>
+      <h3>モバイルから Claude Code に接続</h3>
+      <p>デスクトップで動くシェルセッションに、iPhone / Android から直接アクセス。フル機能のターミナルをモバイルで操作できます。</p>
+    </div>
+    <div class="feature-card card">
+      <div class="feature-icon">🔄</div>
+      <h3>既存セッションを再開</h3>
+      <p>デスクトップで中断した作業セッションに外出先からそのまま再接続。コンテキストを失わずに続きから始められます。</p>
+    </div>
+    <div class="feature-card card">
+      <div class="feature-icon">🖥️</div>
+      <h3>新規セッションや tmux にも接続</h3>
+      <p>プロジェクト単位で新規セッションを開始したり、既存の tmux セッションにアタッチしたりすることも可能です。</p>
+    </div>
+  </div>
+</section>
+
+<!-- ─── 3. HOW IT WORKS ─── -->
+<section id="how-it-works" class="wide-section">
+  <div class="inner">
+    <div class="section-label">利用イメージ / 仕組み</div>
+    <h2>自分の環境に、直接入る</h2>
+    <p class="section-sub">
+      クラウドサーバーを介さず、自分のデスクトップと自分のモバイルが直接つながります。
+      外部に公開されない、閉じた接続です。
+    </p>
+    <div class="arch-diagram">
+      <div class="arch-box">
+        <div class="arch-icon">🖥️</div>
+        <div class="arch-label">Desktop App</div>
+        <div class="arch-desc">Electron + node-pty<br>Claude Code 起動</div>
+      </div>
+      <div class="arch-arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-label">WebSocket<br>over Tailscale</div>
+      </div>
+      <div class="arch-box">
+        <div class="arch-icon">🔒</div>
+        <div class="arch-label">Tailscale VPN</div>
+        <div class="arch-desc">WireGuard 暗号化<br>プライベートネットワーク</div>
+      </div>
+      <div class="arch-arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-label">Token 認証<br>済み接続</div>
+      </div>
+      <div class="arch-box">
+        <div class="arch-icon">📱</div>
+        <div class="arch-label">Mobile App</div>
+        <div class="arch-desc">iOS / Android<br>xterm.js ターミナル</div>
+      </div>
+    </div>
+    <div class="security-note">
+      <span class="icon">🛡️</span>
+      <span>
+        通信は Tailscale の WireGuard 暗号化トンネル内のみを通ります。
+        公開インターネットへのポート開放は不要。クラウドにデータを預けません。
+        あなたの PC と、あなたのモバイルだけで完結します。
+      </span>
+    </div>
+  </div>
+</section>
+
+<!-- ─── 4. 3 STEPS ─── -->
+<section id="get-started">
+  <div class="section-label">3ステップの使い方</div>
+  <h2>セットアップは 3 ステップで完了</h2>
+  <div class="steps">
+    <div class="step">
+      <div class="step-num">1</div>
+      <h3>デスクトップアプリを起動</h3>
+      <p>
+        macOS / Windows / Linux に Remocoder をインストールして起動。
+        Tailscale IP とトークンがトレイアイコンに表示されます。
+      </p>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <h3>モバイルで IP / Token を入力 または QR 読み取り</h3>
+      <p>
+        表示された接続情報を入力するか、QR コードをスキャンするだけ。
+        接続先プロファイルとして保存しておけば次回以降は即接続。
+      </p>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <h3>セッションを選んで作業再開</h3>
+      <p>
+        Active / Idle セッション一覧から選択、または新規セッションを開始。
+        そのままターミナルで作業を続けられます。
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ─── 5. MAIN FEATURES ─── -->
+<section id="main-features">
+  <div class="section-label">主機能</div>
+  <h2>必要なものはすべて揃っている</h2>
+  <div class="feat-grid">
+    <div class="feat-item card">
+      <div class="fi-icon">📷</div>
+      <div>
+        <h4>QR コードで簡単接続</h4>
+        <p>デスクトップ画面に表示された QR コードをスキャンするだけで接続情報を自動入力。</p>
+      </div>
+    </div>
+    <div class="feat-item card">
+      <div class="fi-icon">💾</div>
+      <div>
+        <h4>接続先プロファイル保存</h4>
+        <p>よく使う接続先を保存。次回は一タップで即接続できます。</p>
+      </div>
+    </div>
+    <div class="feat-item card">
+      <div class="fi-icon">📋</div>
+      <div>
+        <h4>Active / Idle セッション一覧</h4>
+        <p>デスクトップで動いているセッションを一覧表示。状態確認も再接続もスムーズ。</p>
+      </div>
+    </div>
+    <div class="feat-item card">
+      <div class="fi-icon">🗂️</div>
+      <div>
+        <h4>プロジェクト単位で新規開始</h4>
+        <p>接続後に好きなプロジェクトで新規 Claude Code セッションをその場で立ち上げ。</p>
+      </div>
+    </div>
+    <div class="feat-item card">
+      <div class="fi-icon">🔀</div>
+      <div>
+        <h4>tmux セッションへアタッチ</h4>
+        <p>既存の tmux セッションにそのまま接続。作業の続きをモバイルで引き継げます。</p>
+      </div>
+    </div>
+    <div class="feat-item card">
+      <div class="fi-icon">⌨️</div>
+      <div>
+        <h4>モバイル向けターミナル UI</h4>
+        <p>スマートフォンの画面に最適化した xterm.js ターミナル。タッチ操作でも快適に使えます。</p>
+      </div>
+    </div>
+    <div class="feat-item card">
+      <div class="fi-icon">✅</div>
+      <div>
+        <h4>権限確認フロー</h4>
+        <p>Claude Code からの権限要求をモバイルで確認・承認できます。外出中でも作業が止まりません。</p>
+      </div>
+    </div>
+    <div class="feat-item card">
+      <div class="fi-icon">🔔</div>
+      <div>
+        <h4>セッション状態の通知</h4>
+        <p>接続断・再接続・セッション終了などの状態変化をリアルタイムに把握できます。</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── 6. SECURITY ─── -->
+<section id="security" class="wide-section">
+  <div class="inner">
+    <div class="section-label">セキュリティ</div>
+    <h2>あなたの環境は、あなただけのもの</h2>
+    <p class="section-sub">
+      クラウドサービスに依存しない設計で、あなたのコードとセッションを守ります。
+    </p>
+    <div class="security-grid">
+      <div class="security-item card">
+        <div class="si-icon">🔒</div>
+        <div>
+          <h4>Tailscale VPN 内のみで通信</h4>
+          <p>すべての通信は Tailscale の WireGuard トンネルを通じて行われます。公開インターネットへのポート開放は一切不要です。</p>
+        </div>
+      </div>
+      <div class="security-item card">
+        <div class="si-icon">🎫</div>
+        <div>
+          <h4>UUID トークン認証</h4>
+          <p>接続時に UUID トークンで認証します。同一 Tailscale ネットワーク内の他デバイスからの不正接続も防ぎます。</p>
+        </div>
+      </div>
+      <div class="security-item card">
+        <div class="si-icon">🌐</div>
+        <div>
+          <h4>公開インターネットへ非公開</h4>
+          <p>サーバーはあなたの Tailscale ネットワーク内にのみ存在します。外部からのアクセスは物理的に不可能です。</p>
+        </div>
+      </div>
+      <div class="security-item card">
+        <div class="si-icon">🏠</div>
+        <div>
+          <h4>自分の PC / セッションに閉じた構成</h4>
+          <p>仲介クラウドサーバーなし。あなたのデスクトップとモバイルが直接つながります。データは外に出ません。</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── 7. TARGET USERS ─── -->
+<section id="target-users">
+  <div class="section-label">こんな人に</div>
+  <h2>想定ユーザー</h2>
+  <div class="user-cards">
+    <div class="user-card card">
+      <div class="uc-icon">🚶</div>
+      <h3>外出先でも開発を続けたい人</h3>
+      <p>カフェや移動中に Claude Code の状況確認や簡単な操作をしたい。ラップトップを開かずにスマホで完結させたい。</p>
+    </div>
+    <div class="user-card card">
+      <div class="uc-icon">💻</div>
+      <h3>デスクトップ作業を中断したくない人</h3>
+      <p>自宅のデスクトップで走らせているセッションを外出先から引き続き監視・操作したい。セッションを閉じずに続けたい。</p>
+    </div>
+    <div class="user-card card">
+      <div class="uc-icon">🔧</div>
+      <h3>自分の開発環境をそのまま使いたい人</h3>
+      <p>クラウド IDE や他人のサーバーは使いたくない。自分のマシン・自分の環境・自分のツールをモバイルから操作したい。</p>
+    </div>
+  </div>
+</section>
+
+<!-- ─── 8. FAQ ─── -->
+<section id="faq">
+  <div class="section-label">よくある質問</div>
+  <h2>FAQ</h2>
+  <div class="faq-list">
+    <details>
+      <summary>Tailscale は必須ですか？</summary>
+      <div class="faq-answer">
+        はい、現時点では Tailscale が必須です。Tailscale は無料プランで個人利用に十分な機能を提供しており、
+        デスクトップとモバイルの両方にインストールして同一ネットワークに参加するだけで使えます。
+        Tailscale のおかげで NAT 越えや VPN 設定を自分で行う必要がなく、簡単に安全な接続を実現できます。
+      </div>
+    </details>
+    <details>
+      <summary>Claude Code はどこで動きますか？</summary>
+      <div class="faq-answer">
+        Claude Code はあなたのデスクトップ PC 上で動作します。モバイルアプリはターミナルの入出力を
+        中継するだけです。処理はすべてあなたのマシンで行われます。
+      </div>
+    </details>
+    <details>
+      <summary>公開サーバーは必要ですか？</summary>
+      <div class="faq-answer">
+        不要です。Remocoder は Tailscale のプライベートネットワーク内のみで動作します。
+        VPS やクラウドサーバーを別途用意する必要はありません。
+      </div>
+    </details>
+    <details>
+      <summary>iPhone と Android の両方に対応していますか？</summary>
+      <div class="faq-answer">
+        はい、iOS / Android 両方に対応しています。React Native（Expo）で構築されているため、
+        どちらのプラットフォームでも同じ体験を提供します。
+      </div>
+    </details>
+    <details>
+      <summary>どの程度安全ですか？</summary>
+      <div class="faq-answer">
+        通信は Tailscale の WireGuard による暗号化トンネルを通ります。さらに接続時に UUID トークン認証を行うため、
+        同一 Tailscale ネットワークの別デバイスからも不正アクセスはできません。
+        クラウドにデータを送ることもなく、あなたの PC とモバイルの間のみで完結します。
+      </div>
+    </details>
+  </div>
+</section>
+
+<!-- ─── 9. FINAL CTA ─── -->
+<section id="cta">
+  <div class="section-label">さあ、始めましょう</div>
+  <h2>自分の PC の Claude Code を、<em>ポケットから開く</em></h2>
+  <p>デスクトップとモバイル、どちらからでも始められます。</p>
+  <div class="cta-btns">
+    <a href="#" class="btn-primary" aria-disabled="true" tabindex="-1">デスクトップ版をダウンロード（準備中）</a>
+    <a href="#" class="btn-secondary" aria-disabled="true" tabindex="-1">モバイル版を見る（準備中）</a>
+  </div>
+</section>
+
+<!-- ─── FOOTER ─── -->
+<footer>
+  <span>© 2026 Remocoder</span>
+  <span>
+    <a href="privacy-policy.html">プライバシーポリシー</a>
+  </span>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Remocoder — 外出先から、デスクトップの Claude Code をそのまま操作</title>
+  <title>RemoCoder — 外出先から、デスクトップの Claude Code をそのまま操作</title>
   <meta name="description" content="Tailscale 経由で安全接続。iPhone / Android から既存セッションにも再接続できるリモートターミナルアプリ。">
-  <meta property="og:title" content="Remocoder — 外出先から、デスクトップの Claude Code をそのまま操作">
+  <meta property="og:title" content="RemoCoder — 外出先から、デスクトップの Claude Code をそのまま操作">
   <meta property="og:description" content="Tailscale 経由で安全接続。iPhone / Android から既存セッションにも再接続できるリモートターミナルアプリ。">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Remocoder — 外出先から、デスクトップの Claude Code をそのまま操作">
+  <meta name="twitter:title" content="RemoCoder — 外出先から、デスクトップの Claude Code をそのまま操作">
   <meta name="twitter:description" content="Tailscale 経由で安全接続。iPhone / Android から既存セッションにも再接続できるリモートターミナルアプリ。">
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <style>
@@ -21,8 +21,8 @@
       --text: #e8e8e8;
       --text-muted: #888;
       --text-dim: #555;
-      --accent: #7c6aff;
-      --accent-dim: #3d3380;
+      --accent: #00c070;
+      --accent-dim: #0a3320;
       --green: #3ddc84;
       --green-dim: #1a4a34;
       --font-mono: "Menlo", "Monaco", "Consolas", "Courier New", monospace;
@@ -150,7 +150,7 @@
       gap: 8px;
       padding: 12px 24px;
       background: var(--accent);
-      color: #fff;
+      color: #0d0d0d;
       border-radius: 8px;
       font-size: 0.9rem;
       font-weight: 600;
@@ -391,8 +391,8 @@
       content: "";
       position: absolute;
       top: 26px;
-      left: calc(16.66% + 16px);
-      right: calc(16.66% + 16px);
+      left: 26px;
+      right: 26px;
       height: 1px;
       background: linear-gradient(to right, var(--accent), var(--green));
     }
@@ -601,7 +601,7 @@
 
 <!-- ─── NAV ─── -->
 <nav aria-label="メインナビゲーション">
-  <a href="#" class="nav-logo">remo<span>coder</span></a>
+  <a href="#" class="nav-logo">Remo<span>Coder</span></a>
   <ul class="nav-links" role="list">
     <li><a href="#features">機能</a></li>
     <li><a href="#how-it-works">仕組み</a></li>
@@ -631,7 +631,7 @@
         <div class="dot dot-red"></div>
         <div class="dot dot-yellow"></div>
         <div class="dot dot-green"></div>
-        <div class="terminal-title">remocoder — claude</div>
+        <div class="terminal-title">RemoCoder — claude</div>
       </div>
       <div class="terminal-body">
         <div class="conn-badge">接続済み — 100.x.x.x:8080</div>
@@ -727,7 +727,7 @@
       <div class="step-num">1</div>
       <h3>デスクトップアプリを起動</h3>
       <p>
-        macOS / Windows / Linux に Remocoder をインストールして起動。
+        macOS / Windows / Linux に RemoCoder をインストールして起動。
         Tailscale IP とトークンがトレイアイコンに表示されます。
       </p>
     </div>
@@ -901,7 +901,7 @@
     <details>
       <summary>公開サーバーは必要ですか？</summary>
       <div class="faq-answer">
-        不要です。Remocoder は Tailscale のプライベートネットワーク内のみで動作します。
+        不要です。RemoCoder は Tailscale のプライベートネットワーク内のみで動作します。
         VPS やクラウドサーバーを別途用意する必要はありません。
       </div>
     </details>
@@ -936,7 +936,7 @@
 
 <!-- ─── FOOTER ─── -->
 <footer>
-  <span>© 2026 Remocoder</span>
+  <span>© 2026 RemoCoder</span>
   <span>
     <a href="privacy-policy.html">プライバシーポリシー</a>
   </span>


### PR DESCRIPTION
## Summary

- issue #114 の画面構成案に基づき `docs/index.html` としてランディングページを実装
- 全幅背景セクションには `.wide-section` クラスを共通化し、カード系要素は `.card` ベースクラスに統一するなど CSS をリファクタリング済み
- インラインスタイルはすべて CSS クラスに移動済み（`style=` 属性なし）

## セクション構成

| # | セクション | 内容 |
|---|---|---|
| 1 | ファーストビュー (Hero) | メインコピー・サブコピー・CTA・ターミナルモックアップ |
| 2 | 何ができるか | 3カラム機能紹介 |
| 3 | 利用イメージ / 仕組み | Desktop → Tailscale → Mobile のアーキテクチャ図 |
| 4 | 3ステップの使い方 | ステップ番号付き手順 |
| 5 | 主機能 | 8機能を2カラムグリッド |
| 6 | セキュリティ | 4項目のセキュリティ訴求 |
| 7 | 想定ユーザー | 3パターンのユーザー像 |
| 8 | FAQ | アコーディオン形式で5問 |
| 9 | 最後の CTA | ダウンロードボタン |

## Test plan

- [ ] `docs/index.html` をブラウザで開きすべてのセクションが表示されることを確認
- [ ] モバイルサイズ（768px 以下）でレスポンシブレイアウトが崩れないことを確認
- [ ] NAV リンクのアンカー遷移が正しく動作することを確認
- [ ] FAQ アコーディオンの開閉が動作することを確認
- [ ] 「準備中」ボタンがクリック不能（`aria-disabled`）になっていることを確認

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)