### PR TITLE
feat: セッション一覧を Rich Card 形式に刷新（フェーズ表示・出力プレビュー・ラベル機能）

### DIFF
--- a/docs/superpowers/plans/2026-06-02-session-list-rich-card.md
+++ b/docs/superpowers/plans/2026-06-02-session-list-rich-card.md
@@ -1,0 +1,1360 @@
+# Session List Rich Card Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** セッション一覧を Rich Card 形式に刷新し、プロジェクト名・種別アイコン・経過時間・最終出力プレビュー・Claudeフェーズ・ユーザー定義ラベルを表示できるようにする。
+
+**Architecture:** `shared/types.ts` の `SessionInfo` に3フィールドを追加し、`pty-server.ts` が PTY 出力のたびにフィールドを更新する。Desktop の `SessionList` と Mobile の `SessionPickerScreen` がそのデータを表示する。ラベルはクライアントサイドのストレージ（localStorage / AsyncStorage）に保存し、サーバーを経由しない。
+
+**Tech Stack:** TypeScript, React (Desktop renderer), React Native + Expo (Mobile), vitest (Desktop tests), jest (Mobile tests), localStorage (Desktop labels), @react-native-async-storage/async-storage (Mobile labels)
+
+---
+
+## ファイルマップ
+
+| ファイル | 変更内容 |
+|--------|---------|
+| `packages/shared/src/types.ts` | `SessionInfo` に `lastActiveAt?`, `lastOutputLine?`, `claudePhase?` を追加 |
+| `packages/desktop/src/main/pty-server.ts` | `PtySession` に新フィールド追加、`updateSessionOutput` 追加、`getSessionInfos` 更新 |
+| `packages/desktop/src/main/__tests__/pty-server.test.ts` | 新フィールドのテストを追加 |
+| `packages/desktop/src/renderer/components/SessionList.tsx` | Rich Card UI に全面刷新、インラインラベル編集追加 |
+| `packages/desktop/src/renderer/__tests__/SessionList.test.tsx` | 新しい表示仕様に合わせてテスト更新 |
+| `packages/mobile/src/screens/SessionPickerScreen.tsx` | 拡張情報表示 + ラベル表示・編集 |
+
+---
+
+## Task 1: SessionInfo 型拡張（shared/types.ts）
+
+**Files:**
+- Modify: `packages/shared/src/types.ts`
+
+- [ ] **Step 1: `SessionInfo` に3フィールドを追加する**
+
+`packages/shared/src/types.ts` の `SessionInfo` インターフェースを以下のように変更する：
+
+```typescript
+export interface SessionInfo {
+  id: string
+  createdAt: string
+  status: 'active' | 'idle'
+  clientIP?: string
+  hasClient?: boolean
+  isExternal?: boolean
+  projectPath?: string
+  source?: SessionSource
+  /** PTYへの最終出力時刻 (ISO 8601) */
+  lastActiveAt?: string
+  /** PTYの最終出力行（ANSI除去済み、最大80文字） */
+  lastOutputLine?: string
+  /** Claudeの処理フェーズ推定 */
+  claudePhase?: 'thinking' | 'writing' | 'waiting' | 'idle'
+}
+```
+
+- [ ] **Step 2: shared のテストが通ることを確認する**
+
+```bash
+cd packages/shared && npx vitest run
+```
+
+Expected: PASS（型変更のみなので既存テストは通る）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add packages/shared/src/types.ts
+git commit -m "feat(shared): SessionInfo に lastActiveAt / lastOutputLine / claudePhase を追加"
+```
+
+---
+
+## Task 2: pty-server — フェーズ検出と出力追跡
+
+**Files:**
+- Modify: `packages/desktop/src/main/pty-server.ts`
+- Test: `packages/desktop/src/main/__tests__/pty-server.test.ts`
+
+- [ ] **Step 1: テストを先に追加する（失敗を確認）**
+
+`packages/desktop/src/main/__tests__/pty-server.test.ts` の末尾、既存の `describe` ブロックの外に以下を追加する：
+
+```typescript
+describe('session_list の claudePhase / lastOutputLine', () => {
+  it('PTY 出力後に session_list_response の sessions[0].lastOutputLine が更新される', async () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    // PTY が出力を生成
+    ptyState.lastShell._onDataCb('Analyzing file.ts\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].lastOutputLine).toBe('Analyzing file.ts')
+  })
+
+  it('スピナー文字を含む出力で claudePhase が "thinking" になる', () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    ptyState.lastShell._onDataCb('⠋ Thinking...\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBe('thinking')
+  })
+
+  it('"Writing" を含む出力で claudePhase が "writing" になる', () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    ptyState.lastShell._onDataCb('Writing src/index.ts\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBe('writing')
+  })
+
+  it('30秒経過後に claudePhase が "idle" になる', () => {
+    vi.useFakeTimers()
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+
+    ptyState.lastShell._onDataCb('⠋ Thinking...\n')
+    vi.advanceTimersByTime(30000)
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBe('idle')
+  })
+})
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```bash
+cd packages/desktop && npx vitest run src/main/__tests__/pty-server.test.ts
+```
+
+Expected: 新規追加した4テストが FAIL（`lastOutputLine` / `claudePhase` が undefined）
+
+- [ ] **Step 3: `pty-server.ts` に定数・型・ヘルパーを追加する**
+
+`packages/desktop/src/main/pty-server.ts` で、既存の定数群（`IDLE_TIMEOUT` など）の直後に以下を追加する：
+
+```typescript
+// Claudeフェーズのアイドル判定時間（ms）
+const CLAUDE_IDLE_TIMEOUT = 30000
+```
+
+`PtySession` インターフェースに以下のフィールドを追加する（`permissionBuffer` フィールドの直前）：
+
+```typescript
+  /** PTYへの最終出力時刻（ms） */
+  lastOutputAt: number
+  /** PTYの最終出力行（ANSI除去済み、最大80文字） */
+  lastOutputLine?: string
+  /** Claudeのフェーズ推定 */
+  claudePhase?: 'thinking' | 'writing' | 'waiting' | 'idle'
+  /** claudePhase を idle にするタイマー */
+  claudeIdleTimeoutId: ReturnType<typeof setTimeout> | null
+```
+
+- [ ] **Step 4: `detectClaudePhase` 関数を追加する**
+
+`pty-server.ts` の `detectAndSendPermission` 関数の直前に追加する：
+
+```typescript
+function detectClaudePhase(line: string): Exclude<SessionInfo['claudePhase'], 'idle' | undefined> | null {
+  if (/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(line)) return 'thinking'
+  if (/Writing|Reading|Editing|Bash|Tool/i.test(line)) return 'writing'
+  if (/\?$|\bEnter\b|\bpress\b|\bconfirm\b/i.test(line)) return 'waiting'
+  return null
+}
+```
+
+- [ ] **Step 5: `updateSessionOutput` 関数を追加する**
+
+`detectClaudePhase` の直後に追加する：
+
+```typescript
+function updateSessionOutput(session: PtySession, data: string): void {
+  const clean = stripAnsi(data)
+  const lines = clean.split('\n').map((l) => l.trim()).filter((l) => l.length > 0)
+  if (lines.length === 0) return
+
+  session.lastOutputAt = Date.now()
+  session.lastOutputLine = lines[lines.length - 1].slice(0, 80)
+
+  const phase = detectClaudePhase(session.lastOutputLine)
+  if (phase !== null) session.claudePhase = phase
+
+  if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
+  session.claudeIdleTimeoutId = setTimeout(() => {
+    const s = ptySessions.get(session.id)
+    if (s) {
+      s.claudePhase = 'idle'
+      notifySessions()
+    }
+  }, CLAUDE_IDLE_TIMEOUT)
+
+  notifySessions()
+}
+```
+
+- [ ] **Step 6: `createPtySession` の PTY 出力ハンドラーに `updateSessionOutput` を呼ぶ**
+
+`ptyProc.onData` のコールバック内、`appendScrollback` の直後に追加する：
+
+```typescript
+ptyProc.onData((data) => {
+  appendScrollback(session, data)
+  updateSessionOutput(session, data)   // ← 追加
+  if (session.wsClient?.readyState === WebSocket.OPEN) {
+    session.wsClient.send(JSON.stringify({ type: 'output', data } satisfies WsMessage))
+  }
+  serverCallbacks.onPtyOutput?.(id, data)
+  detectAndSendPermission(session, data)
+})
+```
+
+- [ ] **Step 7: 外部セッションの出力ハンドラーも更新する**
+
+`isProvider && providerSessionId` ブロック内の `msg.type === 'output'` 処理で、`appendScrollback` の直後に同様に追加する：
+
+```typescript
+if (msg.type === 'output') {
+  appendScrollback(provSession, msg.data)
+  updateSessionOutput(provSession, msg.data)   // ← 追加
+  if (provSession.wsClient?.readyState === WebSocket.OPEN) {
+    provSession.wsClient.send(JSON.stringify({ type: 'output', data: msg.data } satisfies WsMessage))
+  }
+  serverCallbacks.onPtyOutput?.(providerSessionId, msg.data)
+  setSessionActive(provSession)
+  detectAndSendPermission(provSession, msg.data)
+}
+```
+
+- [ ] **Step 8: `createPtySession` / `createExternalSession` の初期値を追加する**
+
+`createPtySession` の `session` オブジェクト初期化に追加：
+
+```typescript
+const session: PtySession = {
+  id,
+  pty: ptyProc,
+  providerWs: null,
+  createdAt: new Date().toISOString(),
+  status: 'active',
+  scrollbackChunks: [],
+  scrollbackLength: 0,
+  wsClient: null,
+  clientIP,
+  idleTimeoutId: null,
+  lastActiveAt: 0,
+  lastOutputAt: 0,          // ← 追加
+  claudeIdleTimeoutId: null, // ← 追加
+  projectPath,
+  source,
+  permissionBuffer: '',
+  pendingPermission: null,
+  detachCleanupId: null,
+}
+```
+
+`createExternalSession` の `session` オブジェクト初期化にも同様に追加：
+
+```typescript
+const session: PtySession = {
+  id,
+  pty: null,
+  providerWs,
+  createdAt: new Date().toISOString(),
+  status: 'active',
+  scrollbackChunks: [],
+  scrollbackLength: 0,
+  wsClient: null,
+  idleTimeoutId: null,
+  lastActiveAt: 0,
+  lastOutputAt: 0,          // ← 追加
+  claudeIdleTimeoutId: null, // ← 追加
+  permissionBuffer: '',
+  pendingPermission: null,
+  detachCleanupId: null,
+}
+```
+
+- [ ] **Step 9: `closeSession` で `claudeIdleTimeoutId` をクリアする**
+
+`closeSession` 内の clearTimeout 群に追加する：
+
+```typescript
+function closeSession(session: PtySession, exitCode: number): void {
+  if (session.idleTimeoutId) clearTimeout(session.idleTimeoutId)
+  if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId) // ← 追加
+  if (session.pendingPermission) clearTimeout(session.pendingPermission.timeoutId)
+  if (session.detachCleanupId) clearTimeout(session.detachCleanupId)
+  // ... 以下変更なし
+}
+```
+
+- [ ] **Step 10: `getSessionInfos` を更新して新フィールドを含める**
+
+```typescript
+function getSessionInfos(): SessionInfo[] {
+  return Array.from(ptySessions.values()).map((s) => ({
+    id: s.id,
+    createdAt: s.createdAt,
+    status: s.status,
+    clientIP: s.clientIP,
+    hasClient: s.wsClient !== null && s.wsClient.readyState === WebSocket.OPEN,
+    isExternal: s.pty === null,
+    projectPath: s.projectPath,
+    source: s.source,
+    lastActiveAt: s.lastOutputAt > 0 ? new Date(s.lastOutputAt).toISOString() : undefined,
+    lastOutputLine: s.lastOutputLine,
+    claudePhase: s.claudePhase,
+  }))
+}
+```
+
+- [ ] **Step 11: テストが通ることを確認する**
+
+```bash
+cd packages/desktop && npx vitest run src/main/__tests__/pty-server.test.ts
+```
+
+Expected: 全テスト PASS
+
+- [ ] **Step 12: コミット**
+
+```bash
+git add packages/desktop/src/main/pty-server.ts packages/desktop/src/main/__tests__/pty-server.test.ts
+git commit -m "feat(desktop): pty-server に Claudeフェーズ検出と最終出力行追跡を追加"
+```
+
+---
+
+## Task 3: Desktop SessionList — Rich Card UI
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/SessionList.tsx`
+- Modify: `packages/desktop/src/renderer/__tests__/SessionList.test.tsx`
+
+- [ ] **Step 1: テストを新しい仕様に合わせて書き直す**
+
+`packages/desktop/src/renderer/__tests__/SessionList.test.tsx` を以下に完全に置き換える：
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { SessionInfo } from '@remocoder/shared'
+import { SessionList } from '../components/SessionList'
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'sess-001',
+    createdAt: new Date(Date.now() - 23 * 60 * 1000).toISOString(), // 23分前
+    status: 'active',
+    hasClient: false,
+    ...overrides,
+  }
+}
+
+describe('SessionList', () => {
+  describe('セッションが 0 件のとき', () => {
+    it('接続待ち中メッセージを表示する', () => {
+      render(<SessionList sessions={[]} />)
+      expect(screen.getByText('Waiting for connections')).toBeInTheDocument()
+    })
+
+    it('カウントに — を表示する', () => {
+      render(<SessionList sessions={[]} />)
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+  })
+
+  describe('セッションが複数あるとき', () => {
+    const sessions = [
+      makeSession({ id: 'sess-001', status: 'active', source: { kind: 'claude', projectPath: '/home/user/remocoder' } }),
+      makeSession({ id: 'sess-002', status: 'idle',   source: { kind: 'shell' } }),
+    ]
+
+    it('件数を "N ACTIVE" 形式で表示する', () => {
+      render(<SessionList sessions={sessions} />)
+      expect(screen.getByText('2 ACTIVE')).toBeInTheDocument()
+    })
+
+    it('active セッションに ACTIVE バッジを表示する', () => {
+      render(<SessionList sessions={sessions} />)
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+    })
+
+    it('idle セッションに IDLE バッジを表示する', () => {
+      render(<SessionList sessions={sessions} />)
+      expect(screen.getByText('IDLE')).toBeInTheDocument()
+    })
+
+    it('プロジェクト名を表示する', () => {
+      render(<SessionList sessions={sessions} />)
+      expect(screen.getByText('remocoder')).toBeInTheDocument()
+    })
+  })
+
+  describe('claudePhase 表示', () => {
+    it('claudePhase が "thinking" のとき THINKING バッジを表示する', () => {
+      render(<SessionList sessions={[makeSession({ claudePhase: 'thinking' })]} />)
+      expect(screen.getByText('THINKING')).toBeInTheDocument()
+    })
+
+    it('claudePhase が "writing" のとき WRITING バッジを表示する', () => {
+      render(<SessionList sessions={[makeSession({ claudePhase: 'writing' })]} />)
+      expect(screen.getByText('WRITING')).toBeInTheDocument()
+    })
+
+    it('claudePhase が "idle" または未設定のときフェーズバッジを表示しない', () => {
+      render(<SessionList sessions={[makeSession({ claudePhase: 'idle' })]} />)
+      expect(screen.queryByText('THINKING')).not.toBeInTheDocument()
+      expect(screen.queryByText('WRITING')).not.toBeInTheDocument()
+      expect(screen.queryByText('WAITING')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('lastOutputLine 表示', () => {
+    it('lastOutputLine があるとき出力プレビューを表示する', () => {
+      render(<SessionList sessions={[makeSession({ lastOutputLine: 'Analyzing src/index.ts' })]} />)
+      expect(screen.getByText('▸ Analyzing src/index.ts')).toBeInTheDocument()
+    })
+
+    it('lastOutputLine がないとき出力プレビューを表示しない', () => {
+      render(<SessionList sessions={[makeSession({ lastOutputLine: undefined })]} />)
+      expect(screen.queryByText(/▸/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('elapsed time', () => {
+    it('経過時間を表示する', () => {
+      render(<SessionList sessions={[makeSession()]} />)
+      expect(screen.getByText(/min ago/)).toBeInTheDocument()
+    })
+  })
+
+  describe('セッションが 1 件のとき', () => {
+    it('1 ACTIVE と表示する', () => {
+      render(<SessionList sessions={[makeSession()]} />)
+      expect(screen.getByText('1 ACTIVE')).toBeInTheDocument()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```bash
+cd packages/desktop && npx vitest run src/renderer/__tests__/SessionList.test.tsx
+```
+
+Expected: 複数テストが FAIL（「remocoder」「THINKING」「▸ Analyzing...」などが見つからない）
+
+- [ ] **Step 3: SessionList.tsx を Rich Card 仕様に全面書き換える**
+
+`packages/desktop/src/renderer/components/SessionList.tsx` を以下に完全に置き換える：
+
+```typescript
+import React, { useState, useEffect } from 'react'
+import type { SessionInfo, SessionSource, MultiplexerSessionInfo } from '@remocoder/shared'
+
+interface SessionListProps {
+  sessions: SessionInfo[]
+  multiplexerSessions?: MultiplexerSessionInfo[]
+  onOpenTerminal?: (sessionId: string) => void
+  onNewSession?: () => void
+  onAttachMultiplexer?: (tool: MultiplexerSessionInfo['tool'], sessionName: string) => void
+  onRefreshMultiplexer?: () => void
+}
+
+// ── ヘルパー関数 ──────────────────────────────────────────────────────────────
+
+function sourceIcon(source?: SessionSource): string {
+  if (!source) return '🖥'
+  switch (source.kind) {
+    case 'claude': return '🤖'
+    case 'shell':  return '🐚'
+    case 'tmux':   return '📟'
+    case 'screen': return '🖥'
+    case 'zellij': return '🪟'
+    default:       return '🖥'
+  }
+}
+
+function resolveProjectName(session: SessionInfo): string | undefined {
+  const path =
+    (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
+    session.projectPath
+  if (!path) return undefined
+  return path.split('/').filter(Boolean).pop()
+}
+
+function formatElapsed(isoString: string): string {
+  const ms = Date.now() - new Date(isoString).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} min ago`
+  const h = Math.floor(m / 60)
+  return `${h} hr ago`
+}
+
+function formatLastActive(isoString?: string): string | undefined {
+  if (!isoString) return undefined
+  const ms = Date.now() - new Date(isoString).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 5) return 'active just now'
+  if (s < 60) return `active ${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `active ${m} min ago`
+  return undefined // 1時間以上前は表示しない
+}
+
+function getLabelKey(sessionId: string): string {
+  return `session-label-${sessionId}`
+}
+
+function loadLabel(sessionId: string): string {
+  try {
+    return localStorage.getItem(getLabelKey(sessionId)) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function saveLabel(sessionId: string, label: string): void {
+  try {
+    if (label.trim()) {
+      localStorage.setItem(getLabelKey(sessionId), label.trim())
+    } else {
+      localStorage.removeItem(getLabelKey(sessionId))
+    }
+  } catch {
+    // localStorage 不使用環境（テスト等）では無視
+  }
+}
+
+// ── SessionRow ───────────────────────────────────────────────────────────────
+
+function SessionRow({
+  session,
+  index,
+  onOpen,
+}: {
+  session: SessionInfo
+  index: number
+  onOpen?: (id: string) => void
+}) {
+  const isActive = session.status === 'active'
+  const hasClient = session.hasClient ?? false
+  const isThinking = session.claudePhase === 'thinking' || session.claudePhase === 'writing'
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [labelValue, setLabelValue] = useState(() => loadLabel(session.id))
+
+  const projectName = resolveProjectName(session)
+  const displayName = labelValue || projectName || session.clientIP || `client_${session.id.slice(0, 6)}`
+
+  const handleLabelBlur = () => {
+    saveLabel(session.id, labelValue)
+    setIsEditing(false)
+  }
+
+  const handleLabelKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      saveLabel(session.id, labelValue)
+      setIsEditing(false)
+    }
+    if (e.key === 'Escape') {
+      setLabelValue(loadLabel(session.id))
+      setIsEditing(false)
+    }
+  }
+
+  const phaseLabel = (() => {
+    switch (session.claudePhase) {
+      case 'thinking': return 'THINKING'
+      case 'writing':  return 'WRITING'
+      case 'waiting':  return 'WAITING'
+      default:         return null
+    }
+  })()
+
+  const phaseColor = (() => {
+    switch (session.claudePhase) {
+      case 'thinking': return 'var(--blue, #60a5fa)'
+      case 'writing':  return 'var(--green)'
+      case 'waiting':  return 'var(--amber)'
+      default:         return undefined
+    }
+  })()
+
+  const lastActiveText = formatLastActive(session.lastActiveAt)
+  const metaParts = [
+    session.isExternal ? 'EXTERNAL' : session.clientIP,
+    formatElapsed(session.createdAt),
+    lastActiveText,
+  ].filter(Boolean)
+
+  return (
+    <div style={{ ...styles.card, animationDelay: `${index * 0.06}s` }}>
+      {/* ヘッダー行 */}
+      <div style={styles.cardHeader}>
+        <div style={styles.cardLeft}>
+          <span
+            style={{
+              ...styles.dot,
+              backgroundColor: isActive ? 'var(--green)' : 'var(--amber)',
+              boxShadow: isActive ? '0 0 5px var(--green)' : '0 0 4px var(--amber)',
+              animation: isActive
+                ? 'pulse-green 2s ease-in-out infinite'
+                : 'pulse-amber 1.8s ease-in-out infinite',
+            }}
+          />
+          <span style={styles.icon}>{sourceIcon(session.source)}</span>
+          {isEditing ? (
+            <input
+              style={styles.labelInput}
+              value={labelValue}
+              autoFocus
+              onChange={(e) => setLabelValue(e.target.value)}
+              onBlur={handleLabelBlur}
+              onKeyDown={handleLabelKeyDown}
+              placeholder={projectName ?? 'Session name'}
+            />
+          ) : (
+            <span
+              style={styles.labelText}
+              title="Click to rename"
+              onClick={() => setIsEditing(true)}
+            >
+              {displayName}
+              <span style={styles.editHint}>✎</span>
+            </span>
+          )}
+        </div>
+        <div style={styles.cardRight}>
+          {phaseLabel && (
+            <span style={{ ...styles.phaseBadge, color: phaseColor, borderColor: phaseColor }}>
+              {phaseLabel}
+            </span>
+          )}
+          <span
+            style={{
+              ...styles.statusBadge,
+              color: isActive ? 'var(--green)' : 'var(--amber)',
+              borderColor: isActive ? 'var(--green-dim)' : 'var(--amber-dim)',
+              background: isActive ? 'var(--green-pulse)' : 'var(--amber-glow)',
+            }}
+          >
+            {session.status.toUpperCase()}
+            {hasClient ? ' · Connected' : ''}
+          </span>
+          {onOpen && (
+            <button style={styles.openButton} onClick={() => onOpen(session.id)} title="Open terminal">
+              <TerminalIcon />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* メタ情報行 */}
+      {metaParts.length > 0 && (
+        <div style={styles.cardMeta}>
+          {metaParts.map((part, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && <span style={styles.metaSep}>·</span>}
+              <span style={styles.metaText}>{part}</span>
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+
+      {/* アクティビティバー */}
+      {isThinking && <div style={styles.activityBar} />}
+
+      {/* 最終出力プレビュー */}
+      {session.lastOutputLine && (
+        <div style={styles.outputPreview}>▸ {session.lastOutputLine}</div>
+      )}
+    </div>
+  )
+}
+
+// ── MultiplexerRow（変更なし） ────────────────────────────────────────────────
+
+function toolLabel(tool: MultiplexerSessionInfo['tool']): string {
+  return tool.toUpperCase()
+}
+
+function MultiplexerRow({
+  info,
+  index,
+  onAttach,
+}: {
+  info: MultiplexerSessionInfo
+  index: number
+  onAttach?: (tool: MultiplexerSessionInfo['tool'], sessionName: string) => void
+}) {
+  return (
+    <div style={{ ...styles.card, animationDelay: `${index * 0.06}s` }}>
+      <div style={styles.cardHeader}>
+        <div style={styles.cardLeft}>
+          <span style={{ ...styles.statusBadge, color: 'var(--amber)', borderColor: 'var(--amber-dim)', background: 'var(--amber-glow)' }}>
+            {toolLabel(info.tool)}
+          </span>
+          <span style={styles.labelText}>{info.sessionName}</span>
+        </div>
+        <div style={styles.cardRight}>
+          {onAttach && (
+            <button style={styles.openButton} onClick={() => onAttach(info.tool, info.sessionName)} title="Attach">
+              <AttachIcon />
+            </button>
+          )}
+        </div>
+      </div>
+      {(info.detail || info.workingDirectory) && (
+        <div style={styles.cardMeta}>
+          {info.detail && <span style={styles.metaText}>{info.detail}</span>}
+          {info.workingDirectory && (
+            <>
+              {info.detail && <span style={styles.metaSep}>·</span>}
+              <span style={{ ...styles.metaText, fontFamily: 'monospace' }} title={info.workingDirectory}>
+                {info.workingDirectory}
+              </span>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── SessionList ───────────────────────────────────────────────────────────────
+
+export function SessionList({
+  sessions,
+  multiplexerSessions,
+  onOpenTerminal,
+  onNewSession,
+  onAttachMultiplexer,
+  onRefreshMultiplexer,
+}: SessionListProps) {
+  const hasMux = multiplexerSessions && multiplexerSessions.length > 0
+
+  return (
+    <>
+      <section style={styles.section}>
+        <div style={styles.sectionHeader}>
+          <span style={styles.sectionLabel}>CONNECTIONS</span>
+          <div style={styles.headerLine} />
+          <span style={styles.count}>
+            {sessions.length > 0 ? `${sessions.length} ACTIVE` : '—'}
+          </span>
+          {onNewSession && (
+            <button style={styles.newButton} onClick={onNewSession} title="Create new session">
+              <PlusIcon />
+            </button>
+          )}
+        </div>
+
+        {sessions.length === 0 ? (
+          <div style={styles.empty}>
+            <div style={styles.emptyIcon}><WifiIcon /></div>
+            <p style={styles.emptyText}>Waiting for connections</p>
+            <p style={styles.emptySubText}>
+              <span style={{ color: 'var(--green)', animation: 'blink 1.2s step-end infinite' }}>▮</span>
+              {' '}Waiting for connection from mobile app
+            </p>
+            {onNewSession && (
+              <button style={styles.newSessionBtn} onClick={onNewSession}>
+                + Create new session
+              </button>
+            )}
+          </div>
+        ) : (
+          <div style={styles.list}>
+            {sessions.map((s, i) => (
+              <SessionRow key={s.id} session={s} index={i} onOpen={onOpenTerminal} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {multiplexerSessions !== undefined && (
+        <section style={styles.section}>
+          <div style={styles.sectionHeader}>
+            <span style={styles.sectionLabel}>MULTIPLEXERS</span>
+            <div style={styles.headerLine} />
+            <span style={{ ...styles.count, color: hasMux ? 'var(--amber)' : 'var(--text-dim)' }}>
+              {hasMux ? `${multiplexerSessions.length} FOUND` : '—'}
+            </span>
+            {onRefreshMultiplexer && (
+              <button style={styles.newButton} onClick={onRefreshMultiplexer} title="Refresh list">
+                <RefreshIcon />
+              </button>
+            )}
+          </div>
+
+          {!hasMux ? (
+            <div style={styles.empty}>
+              <p style={styles.emptyText}>No sessions</p>
+              <p style={styles.emptySubText}>No tmux / screen / zellij sessions found</p>
+            </div>
+          ) : (
+            <div style={styles.list}>
+              {multiplexerSessions.map((m, i) => (
+                <MultiplexerRow
+                  key={`${m.tool}:${m.sessionName}`}
+                  info={m}
+                  index={i}
+                  onAttach={onAttachMultiplexer}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+    </>
+  )
+}
+
+// ── アイコン ─────────────────────────────────────────────────────────────────
+
+function TerminalIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
+    </svg>
+  )
+}
+function PlusIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  )
+}
+function AttachIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+      <polyline points="10 17 15 12 10 7" />
+      <line x1="15" y1="12" x2="3" y2="12" />
+    </svg>
+  )
+}
+function RefreshIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="23 4 23 10 17 10" />
+      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+    </svg>
+  )
+}
+function WifiIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+      <path d="M5 12.55a11 11 0 0114.08 0"/>
+      <path d="M1.42 9a16 16 0 0121.16 0"/>
+      <path d="M8.53 16.11a6 6 0 016.95 0"/>
+      <circle cx="12" cy="20" r="1" fill="currentColor"/>
+    </svg>
+  )
+}
+
+// ── スタイル ─────────────────────────────────────────────────────────────────
+
+const styles: Record<string, React.CSSProperties> = {
+  section: {
+    padding: '14px 16px',
+    borderBottom: '1px solid var(--border)',
+    animation: 'fade-in 0.4s ease forwards',
+    animationDelay: '0.1s',
+    opacity: 0,
+  },
+  sectionHeader: {
+    display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10,
+  },
+  sectionLabel: {
+    fontSize: 9, fontWeight: 700, letterSpacing: '0.15em', color: 'var(--text-muted)', whiteSpace: 'nowrap',
+  },
+  headerLine: { flex: 1, height: 1, background: 'var(--border)' },
+  count: {
+    fontSize: 9, fontWeight: 700, letterSpacing: '0.1em', color: 'var(--green)', whiteSpace: 'nowrap',
+  },
+  newButton: {
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 20, height: 20,
+    background: 'var(--bg-elevated)', border: '1px solid var(--border-bright)',
+    borderRadius: 'var(--radius)', color: 'var(--green)', cursor: 'pointer', padding: 0,
+  },
+  empty: {
+    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, padding: '16px 0', color: 'var(--text-muted)',
+  },
+  emptyIcon: { color: 'var(--text-dim)', marginBottom: 4 },
+  emptyText: { fontSize: 11, fontWeight: 500, color: 'var(--text-muted)', letterSpacing: '0.05em' },
+  emptySubText: { fontSize: 9, color: 'var(--text-dim)', letterSpacing: '0.05em', textAlign: 'center' },
+  newSessionBtn: {
+    marginTop: 8, padding: '5px 12px',
+    background: 'var(--bg-elevated)', border: '1px solid var(--green-dim)',
+    borderRadius: 'var(--radius)', color: 'var(--green)', fontSize: 10, cursor: 'pointer', letterSpacing: '0.05em',
+  },
+  list: { display: 'flex', flexDirection: 'column', gap: 4 },
+  card: {
+    background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius)', overflow: 'hidden',
+    animation: 'slide-in 0.25s ease forwards', opacity: 0,
+  },
+  cardHeader: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    padding: '7px 10px', gap: 6,
+  },
+  cardLeft: { display: 'flex', alignItems: 'center', gap: 6, minWidth: 0, flex: 1 },
+  cardRight: { display: 'flex', alignItems: 'center', gap: 5, flexShrink: 0 },
+  dot: { display: 'inline-block', width: 6, height: 6, borderRadius: '50%', flexShrink: 0 },
+  icon: { fontSize: 12, flexShrink: 0 },
+  labelText: {
+    fontSize: 10, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '0.05em',
+    cursor: 'text', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    display: 'flex', alignItems: 'center', gap: 3,
+  },
+  editHint: { fontSize: 8, color: 'var(--text-dim)', opacity: 0.6 },
+  labelInput: {
+    fontSize: 10, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '0.05em',
+    background: 'var(--bg-base)', border: '1px solid var(--green-dim)',
+    borderRadius: 2, padding: '1px 4px', outline: 'none', minWidth: 0, flex: 1,
+  },
+  cardMeta: {
+    display: 'flex', alignItems: 'center', gap: 4,
+    paddingLeft: 10, paddingRight: 10, paddingBottom: 4, flexWrap: 'wrap',
+  },
+  metaText: { fontSize: 8, color: 'var(--text-muted)', letterSpacing: '0.03em' },
+  metaSep: { fontSize: 8, color: 'var(--text-dim)' },
+  statusBadge: {
+    fontSize: 8, fontWeight: 700, letterSpacing: '0.1em',
+    padding: '2px 6px', border: '1px solid', borderRadius: 2, whiteSpace: 'nowrap', flexShrink: 0,
+  },
+  phaseBadge: {
+    fontSize: 8, fontWeight: 700, letterSpacing: '0.1em',
+    padding: '2px 6px', border: '1px solid', borderRadius: 2, whiteSpace: 'nowrap', flexShrink: 0,
+    background: 'transparent',
+  },
+  activityBar: {
+    height: 2,
+    background: 'linear-gradient(90deg, transparent, var(--green) 50%, transparent)',
+    backgroundSize: '200% 100%',
+    animation: 'activity-scan 1.5s linear infinite',
+  },
+  outputPreview: {
+    padding: '4px 10px', fontSize: 8, color: 'var(--green)',
+    background: 'var(--bg-base)', borderTop: '1px solid var(--border)',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    letterSpacing: '0.03em', fontFamily: 'monospace',
+  },
+  openButton: {
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 22, height: 22, background: 'var(--bg-base)',
+    border: '1px solid var(--border-bright)', borderRadius: 'var(--radius)',
+    color: 'var(--green)', cursor: 'pointer', padding: 0, flexShrink: 0,
+  },
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+```bash
+cd packages/desktop && npx vitest run src/renderer/__tests__/SessionList.test.tsx
+```
+
+Expected: 全テスト PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add packages/desktop/src/renderer/components/SessionList.tsx \
+        packages/desktop/src/renderer/__tests__/SessionList.test.tsx
+git commit -m "feat(desktop): SessionList を Rich Card 形式に刷新（フェーズ表示・出力プレビュー・インラインラベル編集）"
+```
+
+---
+
+## Task 4: Mobile SessionPickerScreen — 拡張情報表示とラベル機能
+
+**Files:**
+- Modify: `packages/mobile/src/screens/SessionPickerScreen.tsx`
+
+- [ ] **Step 1: AsyncStorage のインポートを確認する**
+
+`packages/mobile/src/screens/SessionPickerScreen.tsx` の先頭インポートに `AsyncStorage` が含まれていることを確認する。なければ追加する：
+
+```typescript
+import AsyncStorage from '@react-native-async-storage/async-storage'
+```
+
+- [ ] **Step 2: ヘルパー関数とラベル管理フックを追加する**
+
+`SessionPickerScreen.tsx` のインポートブロック直後（`type ListItem = ...` の前）に追加する：
+
+```typescript
+// ── モバイル用ヘルパー ──────────────────────────────────────────────────────
+
+function mobileSourceIcon(source?: SessionSource): string {
+  if (!source) return '🖥'
+  switch (source.kind) {
+    case 'claude': return '🤖'
+    case 'shell':  return '🐚'
+    case 'tmux':   return '📟'
+    case 'screen': return '🖥'
+    case 'zellij': return '🪟'
+    default:       return '🖥'
+  }
+}
+
+function mobileProjectName(session: SessionInfo): string | undefined {
+  const path =
+    (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
+    session.projectPath
+  if (!path) return undefined
+  return path.split('/').filter(Boolean).pop()
+}
+
+function mobileFormatElapsed(isoString: string): string {
+  const ms = Date.now() - new Date(isoString).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} min ago`
+  const h = Math.floor(m / 60)
+  return `${h} hr ago`
+}
+
+function mobilePhaseBadgeText(phase?: SessionInfo['claudePhase']): string | null {
+  switch (phase) {
+    case 'thinking': return '✦ THINKING'
+    case 'writing':  return '✦ WRITING'
+    case 'waiting':  return '? WAITING'
+    default:         return null
+  }
+}
+
+const LABEL_KEY_PREFIX = 'session-label-'
+
+function useMobileLabels(sessionIds: string[]) {
+  const [labels, setLabels] = React.useState<Record<string, string>>({})
+
+  useEffect(() => {
+    if (sessionIds.length === 0) return
+    const keys = sessionIds.map((id) => LABEL_KEY_PREFIX + id)
+    AsyncStorage.multiGet(keys).then((pairs) => {
+      const map: Record<string, string> = {}
+      pairs.forEach(([key, value]) => {
+        if (value) map[key.replace(LABEL_KEY_PREFIX, '')] = value
+      })
+      setLabels(map)
+    })
+  }, [sessionIds.join(',')])
+
+  const setLabel = async (sessionId: string, label: string) => {
+    if (label.trim()) {
+      await AsyncStorage.setItem(LABEL_KEY_PREFIX + sessionId, label.trim())
+      setLabels((prev) => ({ ...prev, [sessionId]: label.trim() }))
+    } else {
+      await AsyncStorage.removeItem(LABEL_KEY_PREFIX + sessionId)
+      setLabels((prev) => { const next = { ...prev }; delete next[sessionId]; return next })
+    }
+  }
+
+  return { labels, setLabel }
+}
+```
+
+- [ ] **Step 3: `RenameModal` コンポーネントを追加する**
+
+`useMobileLabels` の直後に追加する：
+
+```typescript
+function RenameModal({
+  visible,
+  initialValue,
+  onConfirm,
+  onCancel,
+}: {
+  visible: boolean
+  initialValue: string
+  onConfirm: (value: string) => void
+  onCancel: () => void
+}) {
+  const [value, setValue] = React.useState(initialValue)
+
+  useEffect(() => {
+    if (visible) setValue(initialValue)
+  }, [visible, initialValue])
+
+  if (!visible) return null
+
+  return (
+    <View style={renameStyles.overlay}>
+      <View style={renameStyles.modal}>
+        <Text style={renameStyles.title}>Rename Session</Text>
+        <TextInput
+          style={renameStyles.input}
+          value={value}
+          onChangeText={setValue}
+          placeholder="Session name"
+          placeholderTextColor="#8b949e"
+          autoFocus
+          selectTextOnFocus
+        />
+        <View style={renameStyles.buttons}>
+          <TouchableOpacity style={renameStyles.cancelBtn} onPress={onCancel}>
+            <Text style={renameStyles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={renameStyles.confirmBtn} onPress={() => onConfirm(value)}>
+            <Text style={renameStyles.confirmText}>Save</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const renameStyles = StyleSheet.create({
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    alignItems: 'center', justifyContent: 'center', zIndex: 100,
+  },
+  modal: {
+    backgroundColor: '#161b22', borderRadius: 12, padding: 20,
+    width: '80%', borderWidth: 1, borderColor: 'rgba(255,255,255,0.1)',
+    gap: 14,
+  },
+  title: { color: '#c9d1d9', fontSize: 16, fontWeight: '600' },
+  input: {
+    backgroundColor: '#0d1117', borderWidth: 1, borderColor: 'rgba(255,255,255,0.15)',
+    borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+    color: '#c9d1d9', fontSize: 14,
+  },
+  buttons: { flexDirection: 'row', gap: 10, justifyContent: 'flex-end' },
+  cancelBtn: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 6, backgroundColor: 'rgba(255,255,255,0.06)' },
+  cancelText: { color: '#8b949e', fontSize: 14 },
+  confirmBtn: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 6, backgroundColor: 'rgba(78,201,176,0.15)', borderWidth: 1, borderColor: 'rgba(78,201,176,0.3)' },
+  confirmText: { color: '#4ec9b0', fontSize: 14, fontWeight: '600' },
+})
+```
+
+- [ ] **Step 4: `SessionPickerScreen` に `useMobileLabels` とリネームモーダル状態を追加する**
+
+`SessionPickerScreen` 関数内の `const { connectionStatus, sessions, ... } = useSessionPickerWs(...)` の直後に追加する：
+
+```typescript
+  const sessionIds = useMemo(() => sessions.map((s) => s.id), [sessions])
+  const { labels, setLabel } = useMobileLabels(sessionIds)
+
+  const [renameTarget, setRenameTarget] = React.useState<{ id: string; current: string } | null>(null)
+```
+
+- [ ] **Step 5: `handleDeleteSession` を更新してリネームオプションを追加する**
+
+既存の `handleDeleteSession` を以下に置き換える：
+
+```typescript
+  const handleLongPressSession = useCallback(
+    (session: SessionInfo) => {
+      if (isDeletingSession) return
+      const name = labels[session.id] || getSessionDisplayName(session)
+      Alert.alert(
+        name,
+        'Choose an action',
+        [
+          {
+            text: 'Rename',
+            onPress: () => setRenameTarget({ id: session.id, current: labels[session.id] ?? '' }),
+          },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () => {
+              Alert.alert(
+                'Delete Session',
+                `Terminate and delete "${name}"?`,
+                [
+                  { text: 'Cancel', style: 'cancel' },
+                  { text: 'Delete', style: 'destructive', onPress: () => deleteSession(session.id) },
+                ],
+              )
+            },
+          },
+          { text: 'Cancel', style: 'cancel' },
+        ],
+      )
+    },
+    [isDeletingSession, labels, deleteSession],
+  )
+```
+
+- [ ] **Step 6: `item.kind === 'session'` のレンダリング部分を更新する**
+
+`renderItem` 内の `if (item.kind === 'session')` ブロックを以下に置き換える：
+
+```typescript
+            if (item.kind === 'session') {
+              const { session } = item
+              const label = labels[session.id]
+              const projectName = mobileProjectName(session)
+              const displayName = label || projectName || getSessionDisplayName(session)
+              const icon = mobileSourceIcon(session.source)
+              const phaseBadge = mobilePhaseBadgeText(session.claudePhase)
+              const isDeleting = isDeletingSession && deletingSessionId === session.id
+              return (
+                <TouchableOpacity
+                  style={[styles.sessionRow, isDeleting && styles.sessionRowDeleting]}
+                  onPress={() => !isDeleting && handleAttachSession(session.id)}
+                  onLongPress={() => !isDeleting && handleLongPressSession(session)}
+                  delayLongPress={500}
+                >
+                  <View
+                    style={[
+                      styles.statusDot,
+                      session.status === 'active' ? styles.dotActive : styles.dotIdle,
+                    ]}
+                  />
+                  <View style={styles.sessionInfo}>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                      <Text style={styles.sessionName}>{icon} {displayName}</Text>
+                      {phaseBadge && (
+                        <Text style={mobileSessionStyles.phaseBadge}>{phaseBadge}</Text>
+                      )}
+                    </View>
+                    <Text style={styles.sessionMeta}>
+                      {session.status === 'active' ? 'Active' : 'Idle'}
+                      {session.hasClient ? ' · Connected' : ''}
+                      {' · '}{mobileFormatElapsed(session.createdAt)}
+                    </Text>
+                    {session.lastOutputLine && (
+                      <Text style={mobileSessionStyles.outputPreview} numberOfLines={1}>
+                        ▸ {session.lastOutputLine}
+                      </Text>
+                    )}
+                  </View>
+                  {isDeleting
+                    ? <ActivityIndicator size="small" color="#f85149" />
+                    : <Text style={styles.attachArrow}>→</Text>
+                  }
+                </TouchableOpacity>
+              )
+            }
+```
+
+- [ ] **Step 7: `mobileSessionStyles` を追加する**
+
+ファイル末尾の `const styles = StyleSheet.create({...})` の後に追加する：
+
+```typescript
+const mobileSessionStyles = StyleSheet.create({
+  phaseBadge: {
+    color: '#60a5fa',
+    fontSize: 10,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+  },
+  outputPreview: {
+    color: '#4ec9b0',
+    fontSize: 11,
+    fontFamily: 'monospace',
+    marginTop: 2,
+  },
+})
+```
+
+- [ ] **Step 8: `RenameModal` を `SafeAreaView` 内に追加する**
+
+`SessionPickerScreen` の `return` 内、`</SafeAreaView>` の直前に追加する：
+
+```typescript
+      <RenameModal
+        visible={renameTarget !== null}
+        initialValue={renameTarget?.current ?? ''}
+        onConfirm={(value) => {
+          if (renameTarget) setLabel(renameTarget.id, value)
+          setRenameTarget(null)
+        }}
+        onCancel={() => setRenameTarget(null)}
+      />
+```
+
+- [ ] **Step 9: 型エラーがないことを確認する**
+
+```bash
+cd packages/mobile && npx tsc --noEmit
+```
+
+Expected: エラーなし（または既存の型エラーのみ）
+
+- [ ] **Step 10: コミット**
+
+```bash
+git add packages/mobile/src/screens/SessionPickerScreen.tsx
+git commit -m "feat(mobile): SessionPickerScreen に拡張情報表示・ラベル機能・リネームモーダルを追加"
+```
+
+---
+
+## 最終確認
+
+- [ ] **全テストが通ることを確認する**
+
+```bash
+cd packages/desktop && npx vitest run
+cd packages/mobile && npx jest --passWithNoTests
+```
+
+Expected: 全テスト PASS
+
+- [ ] **デスクトップアプリで動作確認する**
+
+```bash
+cd packages/desktop && npm run dev
+```
+
+確認項目:
+- セッション一覧にプロジェクト名・絵文字アイコンが表示される
+- 経過時間が「N min ago」形式で表示される
+- PTY出力後に最終出力行プレビューが表示される
+- `claudePhase` バッジ（THINKING/WRITING/WAITING）が表示される
+- セッション名をクリックするとインライン編集できる
+- 編集したラベルが再起動後も保持される
+
+- [ ] **最終コミット（必要であれば）**
+
+```bash
+git add -A
+git commit -m "chore: session list rich card 実装完了"
+```

--- a/docs/superpowers/specs/2026-06-02-session-list-rich-card-design.md
+++ b/docs/superpowers/specs/2026-06-02-session-list-rich-card-design.md
@@ -97,9 +97,9 @@ ANSI除去には軽量な正規表現を使用：`/\x1b\[[0-9;]*m/g`
 
 `SessionRow` に `editingLabel` / `labelValue` の local state を追加。
 
-**`packages/mobile/src/screens/SessionPickerScreen.tsx`（または相当ファイル）**
+**`packages/mobile/src/screens/SessionPickerScreen.tsx`**
 
-Desktop と同等の情報をモバイル用スタイルで表示。ユーザー定義ラベルは `AsyncStorage` を使用。実際のファイルパスは実装前に確認する。
+Desktop と同等の情報をモバイル用スタイルで表示。ユーザー定義ラベルは `AsyncStorage` を使用（キー: `session-label-${sessionId}`）。
 
 ---
 

--- a/docs/superpowers/specs/2026-06-02-session-list-rich-card-design.md
+++ b/docs/superpowers/specs/2026-06-02-session-list-rich-card-design.md
@@ -1,0 +1,123 @@
+# Session List Rich Card Design
+
+**Date:** 2026-06-02  
+**Status:** Approved
+
+## 概要
+
+セッション一覧（Desktop: `SessionList`、Mobile: `SessionPickerScreen`）に「何をしているか」が一目でわかる情報を追加する。各セッションをリッチカード形式で表示し、プロジェクト名・種別アイコン・経過時間・最終出力プレビュー・Claudeフェーズ・アクティビティインジケーター・ユーザー定義ラベルを表示する。
+
+---
+
+## 要件
+
+### 表示する情報
+
+| 情報 | データソース | 備考 |
+|------|-------------|------|
+| プロジェクト名 | `SessionInfo.source.projectPath` または `SessionInfo.projectPath` | パス末尾のディレクトリ名のみ表示 |
+| セッション種別アイコン | `SessionInfo.source.kind` | claude/shell/tmux/screen/zellij に対応する絵文字または SVG |
+| 経過時間 | `SessionInfo.createdAt` から計算 | 「23 min ago」形式 |
+| 最終アクティブ時刻 | `SessionInfo.lastActiveAt`（新規追加） | 「active 30s ago」形式 |
+| 最終出力行プレビュー | `SessionInfo.lastOutputLine`（新規追加） | 先頭80文字、カード下部に表示 |
+| Claudeフェーズ | `SessionInfo.claudePhase`（新規追加） | THINKING / WRITING / WAITING / IDLE |
+| アクティビティインジケーター | `claudePhase` が thinking/writing の場合 | カードに流れるアニメーションバー |
+| ユーザー定義ラベル | `localStorage`（Desktop）/ `AsyncStorage`（Mobile） | インライン編集、セッションIDをキーに保存 |
+
+### ユーザー定義ラベルの動作
+
+- カードのプロジェクト名部分をクリックすると `<input>` に切り替わりインライン編集
+- Enter または blur で確定、保存先は `localStorage`（キー: `session-label-${sessionId}`）
+- ラベルが未設定の場合はプロジェクト名（またはセッションID短縮形）を表示
+- 編集モード時は鉛筆アイコンをクリッカブルヒントとして表示
+
+---
+
+## アーキテクチャ
+
+### データ層の変更
+
+**`packages/shared/src/types.ts`**
+
+`SessionInfo` に以下を追加：
+
+```typescript
+lastActiveAt?: string        // PTYへの最終出力時刻 (ISO 8601)
+lastOutputLine?: string      // PTYの最終出力行（ANSI除去済み、最大80文字）
+claudePhase?: 'thinking' | 'writing' | 'waiting' | 'idle'
+```
+
+### サーバー層の変更
+
+**`packages/desktop/src/main/pty-server.ts`**
+
+PTY出力 (`shell.onData`) のたびに以下を更新：
+
+- `lastActiveAt`: `new Date().toISOString()`
+- `lastOutputLine`: ANSI エスケープを除去した最終行（空行はスキップ）
+- `claudePhase`: 下記パターンマッチで推定
+
+**Claudeフェーズ判定ロジック（優先順）：**
+
+1. `thinking`: 行にブレイルスピナー文字（`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`）が含まれる
+2. `writing`: 行に `Writing` / `Reading` / `Editing` / `Bash` / `Tool` が含まれる  
+3. `waiting`: 行末が `?` で終わる、または `Enter` / `press` / `confirm` が含まれる
+4. 出力から30秒以上経過した場合 → `idle`（タイムアウトで更新）
+5. それ以外 → `idle`
+
+ANSI除去には軽量な正規表現を使用：`/\x1b\[[0-9;]*m/g`
+
+`session_list` / `session_list_response` メッセージで送信する `SessionInfo` に上記フィールドを含める。
+
+### UI層の変更
+
+**`packages/desktop/src/renderer/components/SessionList.tsx`**
+
+`SessionRow` を Rich Card 形式に置き換える。カード構造：
+
+```
+┌─────────────────────────────────────────────┐
+│ [dot] [icon] [label/project]   [phase] [btn]│
+│       [ip] · [elapsed] · [lastActive]       │
+│▓▓▓▓▓▓░░░░░░░░░░░░  ← アクティビティバー     │
+│ ▸ Analyzing packages/mobile/src/...         │
+└─────────────────────────────────────────────┘
+```
+
+- アクティビティバー: `claudePhase` が `thinking` または `writing` の場合のみ表示（CSS animation）
+- フェーズバッジ: `THINKING` は青、`WRITING` は緑、`WAITING` は黄、`IDLE` は非表示
+- 最終出力プレビュー: カード下部、monospace、緑系の薄い文字色
+
+**ユーザー定義ラベルのインライン編集：**
+
+```
+通常時: [icon] remocoder ✎（hover時に表示）
+編集時: [icon] [______remocoder______]（input focus）
+```
+
+`SessionRow` に `editingLabel` / `labelValue` の local state を追加。
+
+**`packages/mobile/src/screens/SessionPickerScreen.tsx`（または相当ファイル）**
+
+Desktop と同等の情報をモバイル用スタイルで表示。ユーザー定義ラベルは `AsyncStorage` を使用。実際のファイルパスは実装前に確認する。
+
+---
+
+## 実装しないこと（スコープ外）
+
+- サーバー側での `claudePhase` の精度向上（機械学習・複雑なパーサー等）
+- セッション間でのラベル同期（Desktop ↔ Mobile 間はスコープ外）
+- ラベルの削除UI（空文字で上書きすれば実質削除）
+
+---
+
+## 受け入れ条件
+
+- [ ] セッション一覧にプロジェクト名（またはユーザー定義ラベル）が表示される
+- [ ] 種別アイコン（claude/shell/tmux/screen/zellij）が表示される
+- [ ] 「N min ago」形式の経過時間が表示される
+- [ ] `lastOutputLine` がカード下部にプレビュー表示される（未取得時は非表示）
+- [ ] `claudePhase` に応じたバッジとアクティビティバーが表示される
+- [ ] カードのラベル部分をクリックするとインライン編集できる
+- [ ] 編集したラベルが再起動後も保持される
+- [ ] 既存の「Open terminal」ボタンの動作が壊れない

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/desktop",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./out/main/index.js",

--- a/packages/desktop/src/main/__tests__/pty-server.test.ts
+++ b/packages/desktop/src/main/__tests__/pty-server.test.ts
@@ -712,4 +712,23 @@ describe('session_list の claudePhase / lastOutputLine', () => {
     const response = calls.find((m: any) => m.type === 'session_list_response')
     expect(response.sessions[0].claudePhase).toBe('idle')
   })
+
+  it('チャンク境界で分割された出力でも lastOutputLine が正しく組み立てられる', async () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    // "Writing file.ts\n" が 2 チャンクに分割された場合
+    ptyState.lastShell._onDataCb('Wri')
+    ptyState.lastShell._onDataCb('ting file.ts\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].lastOutputLine).toBe('Writing file.ts')
+    expect(response.sessions[0].claudePhase).toBe('writing')
+  })
 })

--- a/packages/desktop/src/main/__tests__/pty-server.test.ts
+++ b/packages/desktop/src/main/__tests__/pty-server.test.ts
@@ -573,3 +573,88 @@ describe('startPtyServer', () => {
     })
   })
 })
+
+describe('session_list の claudePhase / lastOutputLine', () => {
+  let startPtyServer: (port?: number, callbacks?: any) => { wss: any; getToken: () => string }
+
+  beforeEach(async () => {
+    vi.resetModules()
+    delete process.env.REMOTE_TOKEN
+    mockUuidv4.mockReturnValue('test-token')
+    wssState.instance = null
+    ptyState.lastShell = null
+    const mod = await import('../pty-server')
+    startPtyServer = mod.startPtyServer
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('PTY 出力後に session_list_response の sessions[0].lastOutputLine が更新される', async () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    // PTY が出力を生成
+    ptyState.lastShell._onDataCb('Analyzing file.ts\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].lastOutputLine).toBe('Analyzing file.ts')
+  })
+
+  it('スピナー文字を含む出力で claudePhase が "thinking" になる', () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    ptyState.lastShell._onDataCb('⠋ Thinking...\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBe('thinking')
+  })
+
+  it('"Writing" を含む出力で claudePhase が "writing" になる', () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    ptyState.lastShell._onDataCb('Writing src/index.ts\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBe('writing')
+  })
+
+  it('30秒経過後に claudePhase が "idle" になる', () => {
+    vi.useFakeTimers()
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+
+    ptyState.lastShell._onDataCb('⠋ Thinking...\n')
+    vi.advanceTimersByTime(30000)
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBe('idle')
+  })
+})

--- a/packages/desktop/src/main/__tests__/pty-server.test.ts
+++ b/packages/desktop/src/main/__tests__/pty-server.test.ts
@@ -731,4 +731,22 @@ describe('session_list の claudePhase / lastOutputLine', () => {
     expect(response.sessions[0].lastOutputLine).toBe('Writing file.ts')
     expect(response.sessions[0].claudePhase).toBe('writing')
   })
+
+  it('改行なしの入力待ちプロンプトでも claudePhase と lastOutputLine が更新される', async () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    // 改行なしで "?" 終端のプロンプト（入力待ち）
+    ptyState.lastShell._onDataCb('Do you want to continue?')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].lastOutputLine).toBe('Do you want to continue?')
+    expect(response.sessions[0].claudePhase).toBe('waiting')
+  })
 })

--- a/packages/desktop/src/main/__tests__/pty-server.test.ts
+++ b/packages/desktop/src/main/__tests__/pty-server.test.ts
@@ -749,4 +749,22 @@ describe('session_list の claudePhase / lastOutputLine', () => {
     expect(response.sessions[0].lastOutputLine).toBe('Do you want to continue?')
     expect(response.sessions[0].claudePhase).toBe('waiting')
   })
+
+  it('完了行と改行なしプロンプトが同一チャンクの場合、プロンプト側が lastOutputLine になる', async () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    // "Done\n" (完了行) + "Do you want to continue?" (改行なしプロンプト) が同一チャンク
+    ptyState.lastShell._onDataCb('Done\nDo you want to continue?')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].lastOutputLine).toBe('Do you want to continue?')
+    expect(response.sessions[0].claudePhase).toBe('waiting')
+  })
 })

--- a/packages/desktop/src/main/__tests__/pty-server.test.ts
+++ b/packages/desktop/src/main/__tests__/pty-server.test.ts
@@ -641,6 +641,61 @@ describe('session_list の claudePhase / lastOutputLine', () => {
     expect(response.sessions[0].claudePhase).toBe('writing')
   })
 
+  it('"?" で終わる行で claudePhase が "waiting" になる', () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    ptyState.lastShell._onDataCb('Do you want to continue?\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBe('waiting')
+  })
+
+  it('小文字の "bash" / "toolchain" は claudePhase を変えない', () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    // 小文字 "bash" や "toolchain" は writing にマッチしてはいけない
+    ptyState.lastShell._onDataCb('bash: command not found\n')
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls1 = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const res1 = calls1.find((m: any) => m.type === 'session_list_response')
+    expect(res1.sessions[0].claudePhase).toBeUndefined()
+
+    ws.send.mockClear()
+    ptyState.lastShell._onDataCb('toolchain version 1.2.3\n')
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls2 = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const res2 = calls2.find((m: any) => m.type === 'session_list_response')
+    expect(res2.sessions[0].claudePhase).toBeUndefined()
+  })
+
+  it('"Enter" 単独では claudePhase が "waiting" にならない', () => {
+    startPtyServer()
+    const ws = createMockWs()
+    wssState.instance!.emit('connection', ws)
+    sendMessage(ws, { type: 'auth', token: 'test-token' })
+    sendMessage(ws, { type: 'session_create' })
+    ws.send.mockClear()
+
+    ptyState.lastShell._onDataCb('Enter the virtual environment\n')
+
+    sendMessage(ws, { type: 'session_list_request' })
+    const calls = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+    const response = calls.find((m: any) => m.type === 'session_list_response')
+    expect(response.sessions[0].claudePhase).toBeUndefined()
+  })
+
   it('30秒経過後に claudePhase が "idle" になる', () => {
     vi.useFakeTimers()
     startPtyServer()

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -289,8 +289,10 @@ function sendPermissionRequest(
 
 function detectClaudePhase(line: string): Exclude<SessionInfo['claudePhase'], 'idle' | undefined> | null {
   if (/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(line)) return 'thinking'
-  if (/Writing|Reading|Editing|Bash|Tool/i.test(line)) return 'writing'
-  if (/\?$|\bEnter\b|\bpress\b|\bconfirm\b/i.test(line)) return 'waiting'
+  // 大文字限定で誤検出を防ぐ（"bash", "toolchain" 等の小文字は除外）
+  if (/\bWriting\b|\bReading\b|\bEditing\b|\bBash\b|\bTool\b/.test(line)) return 'writing'
+  // "Press Enter" または "?" 終端のみ: \bEnter\b 単体は "Enter directory" 等に誤マッチするため除外
+  if (/\?$|Press Enter|\bConfirm\b/i.test(line)) return 'waiting'
   return null
 }
 

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -303,7 +303,12 @@ function updateSessionOutput(session: PtySession, data: string): void {
   session.lastOutputLine = lines[lines.length - 1].slice(0, 80)
 
   const phase = detectClaudePhase(session.lastOutputLine)
-  if (phase !== null) session.claudePhase = phase
+  if (phase !== null && phase !== session.claudePhase) {
+    session.claudePhase = phase
+    notifySessions()
+  } else if (phase !== null) {
+    session.claudePhase = phase
+  }
 
   if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
   session.claudeIdleTimeoutId = setTimeout(() => {
@@ -313,8 +318,6 @@ function updateSessionOutput(session: PtySession, data: string): void {
       notifySessions()
     }
   }, CLAUDE_IDLE_TIMEOUT)
-
-  notifySessions()
 }
 
 /**

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -301,15 +301,19 @@ function updateSessionOutput(session: PtySession, data: string): void {
   const lines = clean.split('\n').map((l) => l.trim()).filter((l) => l.length > 0)
   if (lines.length === 0) return
 
+  const prevOutputLine = session.lastOutputLine
+  const prevPhase = session.claudePhase
+
   session.lastOutputAt = Date.now()
   session.lastOutputLine = lines[lines.length - 1].slice(0, 80)
 
   const phase = detectClaudePhase(session.lastOutputLine)
-  if (phase !== null && phase !== session.claudePhase) {
+  if (phase !== null) {
     session.claudePhase = phase
+  }
+
+  if (session.claudePhase !== prevPhase || session.lastOutputLine !== prevOutputLine) {
     notifySessions()
-  } else if (phase !== null) {
-    session.claudePhase = phase
   }
 
   if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -513,6 +513,7 @@ export function getSessions(): SessionInfo[] {
 export function shutdownPtyServer(wss: WebSocketServer): Promise<void> {
   for (const session of ptySessions.values()) {
     if (session.idleTimeoutId) clearTimeout(session.idleTimeoutId)
+    if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
     if (session.detachCleanupId) clearTimeout(session.detachCleanupId)
     if (session.pendingPermission) clearTimeout(session.pendingPermission.timeoutId)
     session.wsClient?.terminate()

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -322,7 +322,11 @@ function updateSessionOutput(session: PtySession, data: string): void {
   const parts = combined.split(/[\r\n]+/)
   // 末尾に改行がなければ最後の断片を次チャンクへ持ち越す
   session.outputLineBuffer = parts[parts.length - 1]
-  const lines = parts.slice(0, -1).map((l) => l.trim()).filter((l) => l.length > 0)
+  const completedLines = parts.slice(0, -1).map((l) => l.trim()).filter((l) => l.length > 0)
+  // 完了行がない場合でもバッファに内容があれば暫定的な最終行として扱う
+  // （改行なしの入力待ちプロンプトや streaming 出力でも更新できるようにする）
+  const bufferLine = session.outputLineBuffer.trim()
+  const lines = completedLines.length > 0 ? completedLines : (bufferLine ? [bufferLine] : [])
   if (lines.length === 0) return
 
   const prevPhase = session.claudePhase

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -179,10 +179,10 @@ function notifySessions() {
   // 認証済み picker クライアントへセッション一覧をプッシュ
   // useSessionPickerWs が処理する session_list 型で送る
   if (pickerSockets.size > 0) {
+    // multiplexerSessions は非同期取得のため含めない（mobile 側でキャッシュ保持）
     const msg = JSON.stringify({
       type: 'session_list',
       sessions: infos,
-      multiplexerSessions: [],
     } satisfies WsMessage)
     for (const sock of pickerSockets) {
       if (sock.readyState === WebSocket.OPEN) sock.send(msg)

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -111,6 +111,8 @@ const SERVER_PING_INTERVAL = 30000
 const PONG_TIMEOUT = 10000
 // アイドル判定時間（ms）
 const IDLE_TIMEOUT = 300000
+// Claudeフェーズのアイドル判定時間（ms）
+const CLAUDE_IDLE_TIMEOUT = 30000
 // スクロールバックの最大バイト数（500KB）
 const SCROLLBACK_MAX_BYTES = 500_000
 // アイドルタイマーを再スケジュールするまでの最小間隔（ms）
@@ -136,6 +138,14 @@ interface PtySession {
   idleTimeoutId: ReturnType<typeof setTimeout> | null
   /** アイドルタイマーを最後にリセットした時刻（デバウンス用） */
   lastActiveAt: number
+  /** PTYへの最終出力時刻（ms） */
+  lastOutputAt: number
+  /** PTYの最終出力行（ANSI除去済み、最大80文字） */
+  lastOutputLine?: string
+  /** Claudeのフェーズ推定 */
+  claudePhase?: 'thinking' | 'writing' | 'waiting' | 'idle'
+  /** claudePhase を idle にするタイマー */
+  claudeIdleTimeoutId: ReturnType<typeof setTimeout> | null
   /** セッションが起動したプロジェクトパス */
   projectPath?: string
   /** セッションの起動元 */
@@ -176,6 +186,9 @@ function getSessionInfos(): SessionInfo[] {
     isExternal: s.pty === null,
     projectPath: s.projectPath,
     source: s.source,
+    lastActiveAt: s.lastOutputAt > 0 ? new Date(s.lastOutputAt).toISOString() : undefined,
+    lastOutputLine: s.lastOutputLine,
+    claudePhase: s.claudePhase,
   }))
 }
 
@@ -185,6 +198,7 @@ function getSessionInfos(): SessionInfo[] {
  */
 function closeSession(session: PtySession, exitCode: number): void {
   if (session.idleTimeoutId) clearTimeout(session.idleTimeoutId)
+  if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
   if (session.pendingPermission) clearTimeout(session.pendingPermission.timeoutId)
   if (session.detachCleanupId) clearTimeout(session.detachCleanupId)
   if (session.wsClient?.readyState === WebSocket.OPEN) {
@@ -273,6 +287,36 @@ function sendPermissionRequest(
   sendPermissionToClient(session.wsClient!, pending)
 }
 
+function detectClaudePhase(line: string): Exclude<SessionInfo['claudePhase'], 'idle' | undefined> | null {
+  if (/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(line)) return 'thinking'
+  if (/Writing|Reading|Editing|Bash|Tool/i.test(line)) return 'writing'
+  if (/\?$|\bEnter\b|\bpress\b|\bconfirm\b/i.test(line)) return 'waiting'
+  return null
+}
+
+function updateSessionOutput(session: PtySession, data: string): void {
+  const clean = stripAnsi(data)
+  const lines = clean.split('\n').map((l) => l.trim()).filter((l) => l.length > 0)
+  if (lines.length === 0) return
+
+  session.lastOutputAt = Date.now()
+  session.lastOutputLine = lines[lines.length - 1].slice(0, 80)
+
+  const phase = detectClaudePhase(session.lastOutputLine)
+  if (phase !== null) session.claudePhase = phase
+
+  if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
+  session.claudeIdleTimeoutId = setTimeout(() => {
+    const s = ptySessions.get(session.id)
+    if (s) {
+      s.claudePhase = 'idle'
+      notifySessions()
+    }
+  }, CLAUDE_IDLE_TIMEOUT)
+
+  notifySessions()
+}
+
 /**
  * PTY出力データから承認プロンプトを検出し、モバイルクライアントへ通知する。
  * 既に pending な承認リクエストがある場合は何もしない。
@@ -350,6 +394,8 @@ function createPtySession(source: SessionSource = { kind: 'claude' }, clientIP?:
     clientIP,
     idleTimeoutId: null,
     lastActiveAt: 0,
+    lastOutputAt: 0,
+    claudeIdleTimeoutId: null,
     projectPath,
     source,
     permissionBuffer: '',
@@ -359,6 +405,7 @@ function createPtySession(source: SessionSource = { kind: 'claude' }, clientIP?:
 
   ptyProc.onData((data) => {
     appendScrollback(session, data)
+    updateSessionOutput(session, data)
     if (session.wsClient?.readyState === WebSocket.OPEN) {
       session.wsClient.send(JSON.stringify({ type: 'output', data } satisfies WsMessage))
     }
@@ -395,6 +442,8 @@ function createExternalSession(providerWs: WebSocket): PtySession {
     wsClient: null,
     idleTimeoutId: null,
     lastActiveAt: 0,
+    lastOutputAt: 0,
+    claudeIdleTimeoutId: null,
     permissionBuffer: '',
     pendingPermission: null,
     detachCleanupId: null,
@@ -619,6 +668,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
 
         if (msg.type === 'output') {
           appendScrollback(provSession, msg.data)
+          updateSessionOutput(provSession, msg.data)
           if (provSession.wsClient?.readyState === WebSocket.OPEN) {
             provSession.wsClient.send(JSON.stringify({ type: 'output', data: msg.data } satisfies WsMessage))
           }

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -160,6 +160,8 @@ interface PtySession {
 
 /** 永続PTYセッションマップ（WS切断後も保持） */
 const ptySessions = new Map<string, PtySession>()
+/** 認証済みかつ未アタッチのモバイル picker 接続セット */
+const pickerSockets = new Set<WebSocket>()
 
 export interface PtyServerCallbacks {
   onSessionsChange?: (sessions: SessionInfo[]) => void
@@ -174,6 +176,18 @@ let serverCallbacks: PtyServerCallbacks = {}
 function notifySessions() {
   const infos = getSessionInfos()
   serverCallbacks.onSessionsChange?.(infos)
+  // 認証済み picker クライアントへセッション一覧をプッシュ
+  if (pickerSockets.size > 0) {
+    const msg = JSON.stringify({
+      type: 'session_list_response',
+      sessions: infos,
+      projects: getRecentProjects(),
+      multiplexerSessions: [],
+    } satisfies WsMessage)
+    for (const sock of pickerSockets) {
+      if (sock.readyState === WebSocket.OPEN) sock.send(msg)
+    }
+  }
 }
 
 function getSessionInfos(): SessionInfo[] {
@@ -298,7 +312,7 @@ function detectClaudePhase(line: string): Exclude<SessionInfo['claudePhase'], 'i
 
 function updateSessionOutput(session: PtySession, data: string): void {
   const clean = stripAnsi(data)
-  const lines = clean.split('\n').map((l) => l.trim()).filter((l) => l.length > 0)
+  const lines = clean.split(/[\r\n]+/).map((l) => l.trim()).filter((l) => l.length > 0)
   if (lines.length === 0) return
 
   const prevOutputLine = session.lastOutputLine
@@ -521,6 +535,7 @@ export function shutdownPtyServer(wss: WebSocketServer): Promise<void> {
     session.pty?.kill()
   }
   ptySessions.clear()
+  pickerSockets.clear()
   // 認証前など ptySessions に未登録の接続も強制終了する
   for (const client of wss.clients) {
     client.terminate()
@@ -627,6 +642,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
       if (!authenticated) {
         if (msg.type === 'auth' && msg.token === AUTH_TOKEN) {
           authenticated = true
+          pickerSockets.add(ws)
           clearTimeout(authTimeout)
           startPingInterval()
           const projects = getRecentProjects()
@@ -709,6 +725,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
           return
         }
         const source = rawSource as SessionSource
+        pickerSockets.delete(ws)
         const session = createPtySession(source, clientIP)
         attachedSessionId = session.id
         session.wsClient = ws
@@ -742,6 +759,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
           clearTimeout(session.detachCleanupId)
           session.detachCleanupId = null
         }
+        pickerSockets.delete(ws)
         detachFromSession()
         // 既存のモバイルクライアントを切断（上書きアタッチ）
         if (
@@ -865,6 +883,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
 
     ws.on('close', () => {
       cleanup()
+      pickerSockets.delete(ws)
 
       // 外部プロバイダーが切断された場合はセッションを終了する
       if (isProvider && providerSessionId) {

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -177,11 +177,11 @@ function notifySessions() {
   const infos = getSessionInfos()
   serverCallbacks.onSessionsChange?.(infos)
   // 認証済み picker クライアントへセッション一覧をプッシュ
+  // useSessionPickerWs が処理する session_list 型で送る
   if (pickerSockets.size > 0) {
     const msg = JSON.stringify({
-      type: 'session_list_response',
+      type: 'session_list',
       sessions: infos,
-      projects: getRecentProjects(),
       multiplexerSessions: [],
     } satisfies WsMessage)
     for (const sock of pickerSockets) {

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -115,6 +115,8 @@ const IDLE_TIMEOUT = 300000
 const CLAUDE_IDLE_TIMEOUT = 30000
 // スクロールバックの最大バイト数（500KB）
 const SCROLLBACK_MAX_BYTES = 500_000
+// 改行なし出力が続いた場合の未完了行バッファ上限（4KB）
+const LINE_BUFFER_MAX_BYTES = 4096
 // アイドルタイマーを再スケジュールするまでの最小間隔（ms）
 const IDLE_TIMER_RESET_INTERVAL = 5000
 // クライアントがデタッチ後に再接続しない場合のセッション自動削除までの時間（ms）
@@ -320,8 +322,10 @@ function updateSessionOutput(session: PtySession, data: string): void {
   // 前回チャンクの未完了行と結合し、改行で分割する
   const combined = session.outputLineBuffer + clean
   const parts = combined.split(/[\r\n]+/)
-  // 末尾に改行がなければ最後の断片を次チャンクへ持ち越す
-  session.outputLineBuffer = parts[parts.length - 1]
+  // 末尾に改行がなければ最後の断片を次チャンクへ持ち越す（上限超過時は末尾を保持）
+  const tail = parts[parts.length - 1]
+  session.outputLineBuffer =
+    tail.length > LINE_BUFFER_MAX_BYTES ? tail.slice(-LINE_BUFFER_MAX_BYTES) : tail
   const completedLines = parts.slice(0, -1).map((l) => l.trim()).filter((l) => l.length > 0)
   // 未完了バッファに内容があれば末尾に追加（完了行の有無に関わらず）
   // 例: "Done\nDo you want to continue?" では bufferLine も判定対象にする

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -148,6 +148,8 @@ interface PtySession {
   claudeIdleTimeoutId: ReturnType<typeof setTimeout> | null
   /** 出力行変化の notifySessions デバウンスタイマー */
   notifyDebounceId: ReturnType<typeof setTimeout> | null
+  /** チャンク境界をまたぐ未完了行バッファ */
+  outputLineBuffer: string
   /** セッションが起動したプロジェクトパス */
   projectPath?: string
   /** セッションの起動元 */
@@ -315,7 +317,12 @@ function detectClaudePhase(line: string): Exclude<SessionInfo['claudePhase'], 'i
 
 function updateSessionOutput(session: PtySession, data: string): void {
   const clean = stripAnsi(data)
-  const lines = clean.split(/[\r\n]+/).map((l) => l.trim()).filter((l) => l.length > 0)
+  // 前回チャンクの未完了行と結合し、改行で分割する
+  const combined = session.outputLineBuffer + clean
+  const parts = combined.split(/[\r\n]+/)
+  // 末尾に改行がなければ最後の断片を次チャンクへ持ち越す
+  session.outputLineBuffer = parts[parts.length - 1]
+  const lines = parts.slice(0, -1).map((l) => l.trim()).filter((l) => l.length > 0)
   if (lines.length === 0) return
 
   const prevPhase = session.claudePhase
@@ -434,6 +441,7 @@ function createPtySession(source: SessionSource = { kind: 'claude' }, clientIP?:
     lastOutputAt: 0,
     claudeIdleTimeoutId: null,
     notifyDebounceId: null,
+    outputLineBuffer: '',
     projectPath,
     source,
     permissionBuffer: '',
@@ -483,6 +491,7 @@ function createExternalSession(providerWs: WebSocket): PtySession {
     lastOutputAt: 0,
     claudeIdleTimeoutId: null,
     notifyDebounceId: null,
+    outputLineBuffer: '',
     permissionBuffer: '',
     pendingPermission: null,
     detachCleanupId: null,

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -323,10 +323,10 @@ function updateSessionOutput(session: PtySession, data: string): void {
   // 末尾に改行がなければ最後の断片を次チャンクへ持ち越す
   session.outputLineBuffer = parts[parts.length - 1]
   const completedLines = parts.slice(0, -1).map((l) => l.trim()).filter((l) => l.length > 0)
-  // 完了行がない場合でもバッファに内容があれば暫定的な最終行として扱う
-  // （改行なしの入力待ちプロンプトや streaming 出力でも更新できるようにする）
+  // 未完了バッファに内容があれば末尾に追加（完了行の有無に関わらず）
+  // 例: "Done\nDo you want to continue?" では bufferLine も判定対象にする
   const bufferLine = session.outputLineBuffer.trim()
-  const lines = completedLines.length > 0 ? completedLines : (bufferLine ? [bufferLine] : [])
+  const lines = bufferLine ? [...completedLines, bufferLine] : completedLines
   if (lines.length === 0) return
 
   const prevPhase = session.claudePhase

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -697,6 +697,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
       // ── 外部ターミナルがセッションをプロバイダー登録する ──────────────────
       if (msg.type === 'session_register') {
         isProvider = true
+        pickerSockets.delete(ws)
         const session = createExternalSession(ws)
         providerSessionId = session.id
         console.log(`[pty-server] External session registered: ${session.id.slice(0, 8)}`)

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -146,6 +146,8 @@ interface PtySession {
   claudePhase?: 'thinking' | 'writing' | 'waiting' | 'idle'
   /** claudePhase を idle にするタイマー */
   claudeIdleTimeoutId: ReturnType<typeof setTimeout> | null
+  /** 出力行変化の notifySessions デバウンスタイマー */
+  notifyDebounceId: ReturnType<typeof setTimeout> | null
   /** セッションが起動したプロジェクトパス */
   projectPath?: string
   /** セッションの起動元 */
@@ -213,6 +215,7 @@ function getSessionInfos(): SessionInfo[] {
 function closeSession(session: PtySession, exitCode: number): void {
   if (session.idleTimeoutId) clearTimeout(session.idleTimeoutId)
   if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
+  if (session.notifyDebounceId) clearTimeout(session.notifyDebounceId)
   if (session.pendingPermission) clearTimeout(session.pendingPermission.timeoutId)
   if (session.detachCleanupId) clearTimeout(session.detachCleanupId)
   if (session.wsClient?.readyState === WebSocket.OPEN) {
@@ -315,7 +318,6 @@ function updateSessionOutput(session: PtySession, data: string): void {
   const lines = clean.split(/[\r\n]+/).map((l) => l.trim()).filter((l) => l.length > 0)
   if (lines.length === 0) return
 
-  const prevOutputLine = session.lastOutputLine
   const prevPhase = session.claudePhase
 
   session.lastOutputAt = Date.now()
@@ -326,8 +328,20 @@ function updateSessionOutput(session: PtySession, data: string): void {
     session.claudePhase = phase
   }
 
-  if (session.claudePhase !== prevPhase || session.lastOutputLine !== prevOutputLine) {
+  if (session.claudePhase !== prevPhase) {
+    // フェーズ変化は即時通知（デバウンスをキャンセル）
+    if (session.notifyDebounceId) {
+      clearTimeout(session.notifyDebounceId)
+      session.notifyDebounceId = null
+    }
     notifySessions()
+  } else {
+    // 出力行のみの変化は 500ms デバウンスして通知頻度を抑える
+    if (session.notifyDebounceId) clearTimeout(session.notifyDebounceId)
+    session.notifyDebounceId = setTimeout(() => {
+      session.notifyDebounceId = null
+      notifySessions()
+    }, 500)
   }
 
   if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
@@ -419,6 +433,7 @@ function createPtySession(source: SessionSource = { kind: 'claude' }, clientIP?:
     lastActiveAt: 0,
     lastOutputAt: 0,
     claudeIdleTimeoutId: null,
+    notifyDebounceId: null,
     projectPath,
     source,
     permissionBuffer: '',
@@ -467,6 +482,7 @@ function createExternalSession(providerWs: WebSocket): PtySession {
     lastActiveAt: 0,
     lastOutputAt: 0,
     claudeIdleTimeoutId: null,
+    notifyDebounceId: null,
     permissionBuffer: '',
     pendingPermission: null,
     detachCleanupId: null,
@@ -528,6 +544,7 @@ export function shutdownPtyServer(wss: WebSocketServer): Promise<void> {
   for (const session of ptySessions.values()) {
     if (session.idleTimeoutId) clearTimeout(session.idleTimeoutId)
     if (session.claudeIdleTimeoutId) clearTimeout(session.claudeIdleTimeoutId)
+    if (session.notifyDebounceId) clearTimeout(session.notifyDebounceId)
     if (session.detachCleanupId) clearTimeout(session.detachCleanupId)
     if (session.pendingPermission) clearTimeout(session.pendingPermission.timeoutId)
     session.wsClient?.terminate()

--- a/packages/desktop/src/renderer/__tests__/App.test.tsx
+++ b/packages/desktop/src/renderer/__tests__/App.test.tsx
@@ -43,7 +43,7 @@ describe('App (MOCK_MODE)', () => {
 
   it('モック API からセッション一覧を取得して表示する', async () => {
     render(<App />)
-    await waitFor(() => expect(screen.getByText('100.88.44.55')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('2 ACTIVE')).toBeInTheDocument())
   })
 
   it('フッターにバージョン情報を表示する', async () => {

--- a/packages/desktop/src/renderer/__tests__/SessionList.test.tsx
+++ b/packages/desktop/src/renderer/__tests__/SessionList.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import type { SessionInfo } from '@remocoder/shared'
 import { SessionList } from '../components/SessionList'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
     id: 'sess-001',
-    createdAt: '2026-03-12T10:00:00.000Z',
+    createdAt: new Date(Date.now() - 23 * 60 * 1000).toISOString(), // 23分前
     status: 'active',
     hasClient: false,
     ...overrides,
@@ -24,24 +24,13 @@ describe('SessionList', () => {
       render(<SessionList sessions={[]} />)
       expect(screen.getByText('—')).toBeInTheDocument()
     })
-
-    it('セッション行を表示しない', () => {
-      render(<SessionList sessions={[]} />)
-      expect(screen.queryByText('ACTIVE')).not.toBeInTheDocument()
-    })
   })
 
   describe('セッションが複数あるとき', () => {
     const sessions = [
-      makeSession({ id: 'sess-001', status: 'active', clientIP: '100.88.44.55' }),
-      makeSession({ id: 'sess-002', status: 'idle',   clientIP: '100.88.44.77' }),
+      makeSession({ id: 'sess-001', status: 'active', source: { kind: 'claude', projectPath: '/home/user/remocoder' } }),
+      makeSession({ id: 'sess-002', status: 'idle',   source: { kind: 'shell' } }),
     ]
-
-    it('すべてのクライアント IP を表示する', () => {
-      render(<SessionList sessions={sessions} />)
-      expect(screen.getByText('100.88.44.55')).toBeInTheDocument()
-      expect(screen.getByText('100.88.44.77')).toBeInTheDocument()
-    })
 
     it('件数を "N ACTIVE" 形式で表示する', () => {
       render(<SessionList sessions={sessions} />)
@@ -58,24 +47,47 @@ describe('SessionList', () => {
       expect(screen.getByText('IDLE')).toBeInTheDocument()
     })
 
-    it('接続待ちメッセージを表示しない', () => {
+    it('プロジェクト名を表示する', () => {
       render(<SessionList sessions={sessions} />)
-      expect(screen.queryByText('Waiting for connections')).not.toBeInTheDocument()
+      expect(screen.getByText('remocoder')).toBeInTheDocument()
     })
   })
 
-  describe('clientIP がないとき', () => {
-    it('client_ + id 先頭 6 文字をフォールバックで表示する', () => {
-      render(<SessionList sessions={[makeSession({ id: 'abcdef123', clientIP: undefined })]} />)
-      expect(screen.getByText('client_abcdef')).toBeInTheDocument()
+  describe('claudePhase 表示', () => {
+    it('claudePhase が "thinking" のとき THINKING バッジを表示する', () => {
+      render(<SessionList sessions={[makeSession({ claudePhase: 'thinking' })]} />)
+      expect(screen.getByText('THINKING')).toBeInTheDocument()
+    })
+
+    it('claudePhase が "writing" のとき WRITING バッジを表示する', () => {
+      render(<SessionList sessions={[makeSession({ claudePhase: 'writing' })]} />)
+      expect(screen.getByText('WRITING')).toBeInTheDocument()
+    })
+
+    it('claudePhase が "idle" または未設定のときフェーズバッジを表示しない', () => {
+      render(<SessionList sessions={[makeSession({ claudePhase: 'idle' })]} />)
+      expect(screen.queryByText('THINKING')).not.toBeInTheDocument()
+      expect(screen.queryByText('WRITING')).not.toBeInTheDocument()
+      expect(screen.queryByText('WAITING')).not.toBeInTheDocument()
     })
   })
 
-  describe('createdAt の時刻フォーマット', () => {
-    it('HH:MM:SS 形式で時刻を表示する', () => {
-      // UTC+0 で 10:00:00 → JST では環境依存のため正規表現で確認
-      render(<SessionList sessions={[makeSession({ createdAt: '2026-03-12T01:23:45.000Z' })]} />)
-      expect(screen.getByText(/\d{2}:\d{2}:\d{2}/)).toBeInTheDocument()
+  describe('lastOutputLine 表示', () => {
+    it('lastOutputLine があるとき出力プレビューを表示する', () => {
+      render(<SessionList sessions={[makeSession({ lastOutputLine: 'Analyzing src/index.ts' })]} />)
+      expect(screen.getByText('▸ Analyzing src/index.ts')).toBeInTheDocument()
+    })
+
+    it('lastOutputLine がないとき出力プレビューを表示しない', () => {
+      render(<SessionList sessions={[makeSession({ lastOutputLine: undefined })]} />)
+      expect(screen.queryByText(/▸/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('elapsed time', () => {
+    it('経過時間を表示する', () => {
+      render(<SessionList sessions={[makeSession()]} />)
+      expect(screen.getByText(/min ago/)).toBeInTheDocument()
     })
   })
 

--- a/packages/desktop/src/renderer/__tests__/SessionList.test.tsx
+++ b/packages/desktop/src/renderer/__tests__/SessionList.test.tsx
@@ -97,4 +97,30 @@ describe('SessionList', () => {
       expect(screen.getByText('1 ACTIVE')).toBeInTheDocument()
     })
   })
+
+  describe('インラインラベル編集', () => {
+    it('ラベルをクリックすると入力欄が表示される', () => {
+      render(<SessionList sessions={[makeSession()]} />)
+      fireEvent.click(screen.getByTitle('Click to rename'))
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    it('Enter キーで編集を確定する', () => {
+      render(<SessionList sessions={[makeSession({ id: 'x1' })]} />)
+      fireEvent.click(screen.getByTitle('Click to rename'))
+      const input = screen.getByRole('textbox')
+      fireEvent.change(input, { target: { value: 'My Session' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    })
+
+    it('Escape キーで編集をキャンセルする', () => {
+      render(<SessionList sessions={[makeSession({ id: 'x2' })]} />)
+      fireEvent.click(screen.getByTitle('Click to rename'))
+      const input = screen.getByRole('textbox')
+      fireEvent.change(input, { target: { value: 'Unwanted Name' } })
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/desktop/src/renderer/components/SessionList.tsx
+++ b/packages/desktop/src/renderer/components/SessionList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import type { SessionInfo, SessionSource, MultiplexerSessionInfo } from '@remocoder/shared'
 
 interface SessionListProps {
@@ -95,6 +95,13 @@ function SessionRow({
   const [isEditing, setIsEditing] = useState(false)
   const [labelValue, setLabelValue] = useState(() => loadLabel(session.id))
   const cancelEditRef = React.useRef(false)
+
+  // 経過時間を1分ごとに更新する
+  const [, forceUpdate] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => forceUpdate((n) => n + 1), 60_000)
+    return () => clearInterval(id)
+  }, [])
 
   const projectName = resolveProjectName(session)
   const displayName = labelValue || projectName || session.clientIP || `client_${session.id.slice(0, 6)}`

--- a/packages/desktop/src/renderer/components/SessionList.tsx
+++ b/packages/desktop/src/renderer/components/SessionList.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
-import type { SessionInfo, SessionSource, MultiplexerSessionInfo } from '@remocoder/shared'
+import type { SessionInfo, MultiplexerSessionInfo } from '@remocoder/shared'
+import { sessionSourceIcon } from '@remocoder/shared'
 
 interface SessionListProps {
   sessions: SessionInfo[]
@@ -11,18 +12,6 @@ interface SessionListProps {
 }
 
 // ── ヘルパー関数 ──────────────────────────────────────────────────────────────
-
-function sourceIcon(source?: SessionSource): string {
-  if (!source) return '🖥'
-  switch (source.kind) {
-    case 'claude': return '🤖'
-    case 'shell':  return '🐚'
-    case 'tmux':   return '📟'
-    case 'screen': return '🖥'
-    case 'zellij': return '🪟'
-    default:       return '🖥'
-  }
-}
 
 function resolveProjectName(session: SessionInfo): string | undefined {
   const path =
@@ -168,7 +157,7 @@ function SessionRow({
                 : 'pulse-amber 1.8s ease-in-out infinite',
             }}
           />
-          <span style={styles.icon}>{sourceIcon(session.source)}</span>
+          <span style={styles.icon}>{sessionSourceIcon(session.source)}</span>
           {isEditing ? (
             <input
               style={styles.labelInput}
@@ -228,7 +217,9 @@ function SessionRow({
       )}
 
       {/* アクティビティバー */}
-      {isThinking && <div style={styles.activityBar} />}
+      {isThinking && (
+        <div style={{ ...styles.activityBar, background: `linear-gradient(90deg, transparent, ${phaseColor} 50%, transparent)` }} />
+      )}
 
       {/* 最終出力プレビュー */}
       {session.lastOutputLine && (

--- a/packages/desktop/src/renderer/components/SessionList.tsx
+++ b/packages/desktop/src/renderer/components/SessionList.tsx
@@ -94,11 +94,17 @@ function SessionRow({
 
   const [isEditing, setIsEditing] = useState(false)
   const [labelValue, setLabelValue] = useState(() => loadLabel(session.id))
+  const cancelEditRef = React.useRef(false)
 
   const projectName = resolveProjectName(session)
   const displayName = labelValue || projectName || session.clientIP || `client_${session.id.slice(0, 6)}`
 
   const handleLabelBlur = () => {
+    if (cancelEditRef.current) {
+      cancelEditRef.current = false
+      setIsEditing(false)
+      return
+    }
     saveLabel(session.id, labelValue)
     setIsEditing(false)
   }
@@ -109,6 +115,7 @@ function SessionRow({
       setIsEditing(false)
     }
     if (e.key === 'Escape') {
+      cancelEditRef.current = true
       setLabelValue(loadLabel(session.id))
       setIsEditing(false)
     }

--- a/packages/desktop/src/renderer/components/SessionList.tsx
+++ b/packages/desktop/src/renderer/components/SessionList.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import type { SessionInfo, MultiplexerSessionInfo } from '@remocoder/shared'
+import React, { useState } from 'react'
+import type { SessionInfo, SessionSource, MultiplexerSessionInfo } from '@remocoder/shared'
 
 interface SessionListProps {
   sessions: SessionInfo[]
@@ -10,13 +10,74 @@ interface SessionListProps {
   onRefreshMultiplexer?: () => void
 }
 
-function formatTime(iso: string): string {
-  const d = new Date(iso)
-  const hh = String(d.getHours()).padStart(2, '0')
-  const mm = String(d.getMinutes()).padStart(2, '0')
-  const ss = String(d.getSeconds()).padStart(2, '0')
-  return `${hh}:${mm}:${ss}`
+// ── ヘルパー関数 ──────────────────────────────────────────────────────────────
+
+function sourceIcon(source?: SessionSource): string {
+  if (!source) return '🖥'
+  switch (source.kind) {
+    case 'claude': return '🤖'
+    case 'shell':  return '🐚'
+    case 'tmux':   return '📟'
+    case 'screen': return '🖥'
+    case 'zellij': return '🪟'
+    default:       return '🖥'
+  }
 }
+
+function resolveProjectName(session: SessionInfo): string | undefined {
+  const path =
+    (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
+    session.projectPath
+  if (!path) return undefined
+  return path.split('/').filter(Boolean).pop()
+}
+
+function formatElapsed(isoString: string): string {
+  const ms = Date.now() - new Date(isoString).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} min ago`
+  const h = Math.floor(m / 60)
+  return `${h} hr ago`
+}
+
+function formatLastActive(isoString?: string): string | undefined {
+  if (!isoString) return undefined
+  const ms = Date.now() - new Date(isoString).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 5) return 'active just now'
+  if (s < 60) return `active ${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `active ${m} min ago`
+  return undefined
+}
+
+function getLabelKey(sessionId: string): string {
+  return `session-label-${sessionId}`
+}
+
+function loadLabel(sessionId: string): string {
+  try {
+    return localStorage.getItem(getLabelKey(sessionId)) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function saveLabel(sessionId: string, label: string): void {
+  try {
+    if (label.trim()) {
+      localStorage.setItem(getLabelKey(sessionId), label.trim())
+    } else {
+      localStorage.removeItem(getLabelKey(sessionId))
+    }
+  } catch {
+    // localStorage 不使用環境（テスト等）では無視
+  }
+}
+
+// ── SessionRow ───────────────────────────────────────────────────────────────
 
 function SessionRow({
   session,
@@ -29,56 +90,141 @@ function SessionRow({
 }) {
   const isActive = session.status === 'active'
   const hasClient = session.hasClient ?? false
+  const isThinking = session.claudePhase === 'thinking' || session.claudePhase === 'writing'
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [labelValue, setLabelValue] = useState(() => loadLabel(session.id))
+
+  const projectName = resolveProjectName(session)
+  const displayName = labelValue || projectName || session.clientIP || `client_${session.id.slice(0, 6)}`
+
+  const handleLabelBlur = () => {
+    saveLabel(session.id, labelValue)
+    setIsEditing(false)
+  }
+
+  const handleLabelKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      saveLabel(session.id, labelValue)
+      setIsEditing(false)
+    }
+    if (e.key === 'Escape') {
+      setLabelValue(loadLabel(session.id))
+      setIsEditing(false)
+    }
+  }
+
+  const phaseLabel = (() => {
+    switch (session.claudePhase) {
+      case 'thinking': return 'THINKING'
+      case 'writing':  return 'WRITING'
+      case 'waiting':  return 'WAITING'
+      default:         return null
+    }
+  })()
+
+  const phaseColor = (() => {
+    switch (session.claudePhase) {
+      case 'thinking': return 'var(--blue, #60a5fa)'
+      case 'writing':  return 'var(--green)'
+      case 'waiting':  return 'var(--amber)'
+      default:         return undefined
+    }
+  })()
+
+  const lastActiveText = formatLastActive(session.lastActiveAt)
+  const metaParts = [
+    session.isExternal ? 'EXTERNAL' : session.clientIP,
+    formatElapsed(session.createdAt),
+    lastActiveText,
+  ].filter(Boolean)
 
   return (
-    <div
-      style={{
-        ...styles.row,
-        animationDelay: `${index * 0.06}s`,
-      }}
-    >
-      {/* Status indicator */}
-      <div style={styles.rowLeft}>
-        <span
-          style={{
-            ...styles.dot,
-            backgroundColor: isActive ? 'var(--green)' : 'var(--amber)',
-            boxShadow: isActive ? '0 0 5px var(--green)' : '0 0 4px var(--amber)',
-            animation: isActive
-              ? 'pulse-green 2s ease-in-out infinite'
-              : 'pulse-amber 1.8s ease-in-out infinite',
-          }}
-        />
-        <div style={styles.sessionInfo}>
-          <span style={styles.sessionId}>
-            {session.clientIP ?? `client_${session.id.slice(0, 6)}`}
+    <div style={{ ...styles.card, animationDelay: `${index * 0.06}s` }}>
+      {/* ヘッダー行 */}
+      <div style={styles.cardHeader}>
+        <div style={styles.cardLeft}>
+          <span
+            style={{
+              ...styles.dot,
+              backgroundColor: isActive ? 'var(--green)' : 'var(--amber)',
+              boxShadow: isActive ? '0 0 5px var(--green)' : '0 0 4px var(--amber)',
+              animation: isActive
+                ? 'pulse-green 2s ease-in-out infinite'
+                : 'pulse-amber 1.8s ease-in-out infinite',
+            }}
+          />
+          <span style={styles.icon}>{sourceIcon(session.source)}</span>
+          {isEditing ? (
+            <input
+              style={styles.labelInput}
+              value={labelValue}
+              autoFocus
+              onChange={(e) => setLabelValue(e.target.value)}
+              onBlur={handleLabelBlur}
+              onKeyDown={handleLabelKeyDown}
+              placeholder={projectName ?? 'Session name'}
+            />
+          ) : (
+            <span
+              style={styles.labelText}
+              title="Click to rename"
+              onClick={() => setIsEditing(true)}
+            >
+              <span style={styles.labelName}>{displayName}</span>
+              <span style={styles.editHint}>✎</span>
+            </span>
+          )}
+        </div>
+        <div style={styles.cardRight}>
+          {phaseLabel && (
+            <span style={{ ...styles.phaseBadge, color: phaseColor, borderColor: phaseColor }}>
+              {phaseLabel}
+            </span>
+          )}
+          <span
+            style={{
+              ...styles.statusBadge,
+              color: isActive ? 'var(--green)' : 'var(--amber)',
+              borderColor: isActive ? 'var(--green-dim)' : 'var(--amber-dim)',
+              background: isActive ? 'var(--green-pulse)' : 'var(--amber-glow)',
+            }}
+          >
+            {session.status.toUpperCase()}
+            {hasClient ? ' · Connected' : ''}
           </span>
-          <span style={styles.sessionTime}>{formatTime(session.createdAt)}</span>
+          {onOpen && (
+            <button style={styles.openButton} onClick={() => onOpen(session.id)} title="Open terminal">
+              <TerminalIcon />
+            </button>
+          )}
         </div>
       </div>
 
-      {/* Right side: badge + open button */}
-      <div style={styles.rowRight}>
-        <span
-          style={{
-            ...styles.badge,
-            color: isActive ? 'var(--green)' : 'var(--amber)',
-            borderColor: isActive ? 'var(--green-dim)' : 'var(--amber-dim)',
-            background: isActive ? 'var(--green-pulse)' : 'var(--amber-glow)',
-          }}
-        >
-          {session.status.toUpperCase()}
-          {hasClient ? ' · Connected' : ''}
-        </span>
-        {onOpen && (
-          <button style={styles.openButton} onClick={() => onOpen(session.id)} title="Open terminal">
-            <TerminalIcon />
-          </button>
-        )}
-      </div>
+      {/* メタ情報行 */}
+      {metaParts.length > 0 && (
+        <div style={styles.cardMeta}>
+          {metaParts.map((part, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && <span style={styles.metaSep}>·</span>}
+              <span style={styles.metaText}>{part}</span>
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+
+      {/* アクティビティバー */}
+      {isThinking && <div style={styles.activityBar} />}
+
+      {/* 最終出力プレビュー */}
+      {session.lastOutputLine && (
+        <div style={styles.outputPreview}>▸ {session.lastOutputLine}</div>
+      )}
     </div>
   )
 }
+
+// ── MultiplexerRow ────────────────────────────────────────────────────────────
 
 function toolLabel(tool: MultiplexerSessionInfo['tool']): string {
   return tool.toUpperCase()
@@ -94,42 +240,40 @@ function MultiplexerRow({
   onAttach?: (tool: MultiplexerSessionInfo['tool'], sessionName: string) => void
 }) {
   return (
-    <div style={{ ...styles.row, animationDelay: `${index * 0.06}s` }}>
-      <div style={styles.rowLeft}>
-        <span
-          style={{
-            ...styles.badge,
-            color: 'var(--amber)',
-            borderColor: 'var(--amber-dim)',
-            background: 'var(--amber-glow)',
-          }}
-        >
-          {toolLabel(info.tool)}
-        </span>
-        <div style={styles.sessionInfo}>
-          <span style={styles.sessionId}>{info.sessionName}</span>
-          {info.detail && <span style={styles.sessionTime}>{info.detail}</span>}
-          {info.workingDirectory && (
-            <span style={styles.sessionPath} title={info.workingDirectory}>
-              {info.workingDirectory}
-            </span>
+    <div style={{ ...styles.card, animationDelay: `${index * 0.06}s` }}>
+      <div style={styles.cardHeader}>
+        <div style={styles.cardLeft}>
+          <span style={{ ...styles.statusBadge, color: 'var(--amber)', borderColor: 'var(--amber-dim)', background: 'var(--amber-glow)' }}>
+            {toolLabel(info.tool)}
+          </span>
+          <span style={styles.labelText}>{info.sessionName}</span>
+        </div>
+        <div style={styles.cardRight}>
+          {onAttach && (
+            <button style={styles.openButton} onClick={() => onAttach(info.tool, info.sessionName)} title="Attach">
+              <AttachIcon />
+            </button>
           )}
         </div>
       </div>
-      <div style={styles.rowRight}>
-        {onAttach && (
-          <button
-            style={styles.openButton}
-            onClick={() => onAttach(info.tool, info.sessionName)}
-            title="Attach to session"
-          >
-            <AttachIcon />
-          </button>
-        )}
-      </div>
+      {(info.detail || info.workingDirectory) && (
+        <div style={styles.cardMeta}>
+          {info.detail && <span style={styles.metaText}>{info.detail}</span>}
+          {info.workingDirectory && (
+            <>
+              {info.detail && <span style={styles.metaSep}>·</span>}
+              <span style={{ ...styles.metaText, fontFamily: 'monospace' }} title={info.workingDirectory}>
+                {info.workingDirectory}
+              </span>
+            </>
+          )}
+        </div>
+      )}
     </div>
   )
 }
+
+// ── SessionList ───────────────────────────────────────────────────────────────
 
 export function SessionList({
   sessions,
@@ -159,9 +303,7 @@ export function SessionList({
 
         {sessions.length === 0 ? (
           <div style={styles.empty}>
-            <div style={styles.emptyIcon}>
-              <WifiIcon />
-            </div>
+            <div style={styles.emptyIcon}><WifiIcon /></div>
             <p style={styles.emptyText}>Waiting for connections</p>
             <p style={styles.emptySubText}>
               <span style={{ color: 'var(--green)', animation: 'blink 1.2s step-end infinite' }}>▮</span>
@@ -182,7 +324,6 @@ export function SessionList({
         )}
       </section>
 
-      {/* マルチプレクサセクション（tmux / screen / zellij） */}
       {multiplexerSessions !== undefined && (
         <section style={styles.section}>
           <div style={styles.sectionHeader}>
@@ -221,6 +362,8 @@ export function SessionList({
   )
 }
 
+// ── アイコン ─────────────────────────────────────────────────────────────────
+
 function TerminalIcon() {
   return (
     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -229,7 +372,6 @@ function TerminalIcon() {
     </svg>
   )
 }
-
 function PlusIcon() {
   return (
     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -238,7 +380,6 @@ function PlusIcon() {
     </svg>
   )
 }
-
 function AttachIcon() {
   return (
     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -248,7 +389,6 @@ function AttachIcon() {
     </svg>
   )
 }
-
 function RefreshIcon() {
   return (
     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -257,18 +397,9 @@ function RefreshIcon() {
     </svg>
   )
 }
-
 function WifiIcon() {
   return (
-    <svg
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    >
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
       <path d="M5 12.55a11 11 0 0114.08 0"/>
       <path d="M1.42 9a16 16 0 0121.16 0"/>
       <path d="M8.53 16.11a6 6 0 016.95 0"/>
@@ -276,6 +407,8 @@ function WifiIcon() {
     </svg>
   )
 }
+
+// ── スタイル ─────────────────────────────────────────────────────────────────
 
 const styles: Record<string, React.CSSProperties> = {
   section: {
@@ -286,174 +419,91 @@ const styles: Record<string, React.CSSProperties> = {
     opacity: 0,
   },
   sectionHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 10,
-    marginBottom: 10,
+    display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10,
   },
   sectionLabel: {
-    fontSize: 9,
-    fontWeight: 700,
-    letterSpacing: '0.15em',
-    color: 'var(--text-muted)',
-    whiteSpace: 'nowrap',
+    fontSize: 9, fontWeight: 700, letterSpacing: '0.15em', color: 'var(--text-muted)', whiteSpace: 'nowrap',
   },
-  headerLine: {
-    flex: 1,
-    height: 1,
-    background: 'var(--border)',
-  },
+  headerLine: { flex: 1, height: 1, background: 'var(--border)' },
   count: {
-    fontSize: 9,
-    fontWeight: 700,
-    letterSpacing: '0.1em',
-    color: 'var(--green)',
-    whiteSpace: 'nowrap',
+    fontSize: 9, fontWeight: 700, letterSpacing: '0.1em', color: 'var(--green)', whiteSpace: 'nowrap',
   },
   newButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 20,
-    height: 20,
-    background: 'var(--bg-elevated)',
-    border: '1px solid var(--border-bright)',
-    borderRadius: 'var(--radius)',
-    color: 'var(--green)',
-    cursor: 'pointer',
-    padding: 0,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 20, height: 20,
+    background: 'var(--bg-elevated)', border: '1px solid var(--border-bright)',
+    borderRadius: 'var(--radius)', color: 'var(--green)', cursor: 'pointer', padding: 0,
   },
   empty: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: 6,
-    padding: '16px 0',
-    color: 'var(--text-muted)',
+    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, padding: '16px 0', color: 'var(--text-muted)',
   },
-  emptyIcon: {
-    color: 'var(--text-dim)',
-    marginBottom: 4,
-  },
-  emptyText: {
-    fontSize: 11,
-    fontWeight: 500,
-    color: 'var(--text-muted)',
-    letterSpacing: '0.05em',
-  },
-  emptySubText: {
-    fontSize: 9,
-    color: 'var(--text-dim)',
-    letterSpacing: '0.05em',
-    textAlign: 'center',
-  },
+  emptyIcon: { color: 'var(--text-dim)', marginBottom: 4 },
+  emptyText: { fontSize: 11, fontWeight: 500, color: 'var(--text-muted)', letterSpacing: '0.05em' },
+  emptySubText: { fontSize: 9, color: 'var(--text-dim)', letterSpacing: '0.05em', textAlign: 'center' },
   newSessionBtn: {
-    marginTop: 8,
-    padding: '5px 12px',
-    background: 'var(--bg-elevated)',
-    border: '1px solid var(--green-dim)',
-    borderRadius: 'var(--radius)',
-    color: 'var(--green)',
-    fontSize: 10,
-    cursor: 'pointer',
-    letterSpacing: '0.05em',
+    marginTop: 8, padding: '5px 12px',
+    background: 'var(--bg-elevated)', border: '1px solid var(--green-dim)',
+    borderRadius: 'var(--radius)', color: 'var(--green)', fontSize: 10, cursor: 'pointer', letterSpacing: '0.05em',
   },
-  list: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 4,
+  list: { display: 'flex', flexDirection: 'column', gap: 4 },
+  card: {
+    background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius)', overflow: 'hidden',
+    animation: 'slide-in 0.25s ease forwards', opacity: 0,
   },
-  row: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: '7px 10px',
-    background: 'var(--bg-elevated)',
-    border: '1px solid var(--border)',
-    borderRadius: 'var(--radius)',
-    animation: 'slide-in 0.25s ease forwards',
-    opacity: 0,
+  cardHeader: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    padding: '7px 10px', gap: 6,
   },
-  rowLeft: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-    minWidth: 0,
-    flex: 1,
+  cardLeft: { display: 'flex', alignItems: 'center', gap: 6, minWidth: 0, flex: 1 },
+  cardRight: { display: 'flex', alignItems: 'center', gap: 5, flexShrink: 0 },
+  dot: { display: 'inline-block', width: 6, height: 6, borderRadius: '50%', flexShrink: 0 },
+  icon: { fontSize: 12, flexShrink: 0 },
+  labelText: {
+    fontSize: 10, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '0.05em',
+    cursor: 'text', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    display: 'flex', alignItems: 'center', gap: 3,
   },
-  rowRight: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 6,
-    flexShrink: 0,
+  labelName: {
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
-  dot: {
-    display: 'inline-block',
-    width: 6,
-    height: 6,
-    borderRadius: '50%',
-    flexShrink: 0,
+  editHint: { fontSize: 8, color: 'var(--text-dim)', opacity: 0.6, flexShrink: 0 },
+  labelInput: {
+    fontSize: 10, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '0.05em',
+    background: 'var(--bg-base)', border: '1px solid var(--green-dim)',
+    borderRadius: 2, padding: '1px 4px', outline: 'none', minWidth: 0, flex: 1,
   },
-  sessionInfo: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 1,
-    minWidth: 0,
+  cardMeta: {
+    display: 'flex', alignItems: 'center', gap: 4,
+    paddingLeft: 10, paddingRight: 10, paddingBottom: 4, flexWrap: 'wrap',
   },
-  sessionId: {
-    fontSize: 10,
-    fontWeight: 600,
-    color: 'var(--text-primary)',
-    letterSpacing: '0.05em',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+  metaText: { fontSize: 8, color: 'var(--text-muted)', letterSpacing: '0.03em' },
+  metaSep: { fontSize: 8, color: 'var(--text-dim)' },
+  statusBadge: {
+    fontSize: 8, fontWeight: 700, letterSpacing: '0.1em',
+    padding: '2px 6px', border: '1px solid', borderRadius: 2, whiteSpace: 'nowrap', flexShrink: 0,
   },
-  sessionTime: {
-    fontSize: 9,
-    color: 'var(--text-muted)',
-    letterSpacing: '0.04em',
+  phaseBadge: {
+    fontSize: 8, fontWeight: 700, letterSpacing: '0.1em',
+    padding: '2px 6px', border: '1px solid', borderRadius: 2, whiteSpace: 'nowrap', flexShrink: 0,
+    background: 'transparent',
   },
-  sessionPath: {
-    fontSize: 9,
-    color: 'var(--text-muted)',
-    fontFamily: 'monospace',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+  activityBar: {
+    height: 2,
+    background: 'linear-gradient(90deg, transparent, var(--green) 50%, transparent)',
+    backgroundSize: '200% 100%',
+    animation: 'activity-scan 1.5s linear infinite',
   },
-  badge: {
-    fontSize: 8,
-    fontWeight: 700,
-    letterSpacing: '0.1em',
-    padding: '2px 6px',
-    border: '1px solid',
-    borderRadius: 2,
-    whiteSpace: 'nowrap',
-    flexShrink: 0,
-  },
-  toolBadge: {
-    fontSize: 8,
-    fontWeight: 700,
-    letterSpacing: '0.1em',
-    padding: '2px 6px',
-    border: '1px solid',
-    borderRadius: 2,
-    whiteSpace: 'nowrap',
-    flexShrink: 0,
+  outputPreview: {
+    padding: '4px 10px', fontSize: 8, color: 'var(--green)',
+    background: 'var(--bg-base)', borderTop: '1px solid var(--border)',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    letterSpacing: '0.03em', fontFamily: 'monospace',
   },
   openButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 22,
-    height: 22,
-    background: 'var(--bg-base)',
-    border: '1px solid var(--border-bright)',
-    borderRadius: 'var(--radius)',
-    color: 'var(--green)',
-    cursor: 'pointer',
-    padding: 0,
-    flexShrink: 0,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    width: 22, height: 22, background: 'var(--bg-base)',
+    border: '1px solid var(--border-bright)', borderRadius: 'var(--radius)',
+    color: 'var(--green)', cursor: 'pointer', padding: 0, flexShrink: 0,
   },
 }

--- a/packages/desktop/src/renderer/components/SessionList.tsx
+++ b/packages/desktop/src/renderer/components/SessionList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import type { SessionInfo, MultiplexerSessionInfo } from '@remocoder/shared'
-import { sessionSourceIcon } from '@remocoder/shared'
+import { sessionSourceIcon, sessionProjectName, formatSessionElapsed } from '@remocoder/shared'
 
 interface SessionListProps {
   sessions: SessionInfo[]
@@ -12,24 +12,6 @@ interface SessionListProps {
 }
 
 // ── ヘルパー関数 ──────────────────────────────────────────────────────────────
-
-function resolveProjectName(session: SessionInfo): string | undefined {
-  const path =
-    (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
-    session.projectPath
-  if (!path) return undefined
-  return path.split('/').filter(Boolean).pop()
-}
-
-function formatElapsed(isoString: string): string {
-  const ms = Date.now() - new Date(isoString).getTime()
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s ago`
-  const m = Math.floor(s / 60)
-  if (m < 60) return `${m} min ago`
-  const h = Math.floor(m / 60)
-  return `${h} hr ago`
-}
 
 function formatLastActive(isoString?: string): string | undefined {
   if (!isoString) return undefined
@@ -92,7 +74,7 @@ function SessionRow({
     return () => clearInterval(id)
   }, [])
 
-  const projectName = resolveProjectName(session)
+  const projectName = sessionProjectName(session)
   const displayName = labelValue || projectName || session.clientIP || `client_${session.id.slice(0, 6)}`
 
   const handleLabelBlur = () => {
@@ -138,7 +120,7 @@ function SessionRow({
   const lastActiveText = formatLastActive(session.lastActiveAt)
   const metaParts = [
     session.isExternal ? 'EXTERNAL' : session.clientIP,
-    formatElapsed(session.createdAt),
+    formatSessionElapsed(session.createdAt),
     lastActiveText,
   ].filter(Boolean)
 

--- a/packages/desktop/src/renderer/index.css
+++ b/packages/desktop/src/renderer/index.css
@@ -93,3 +93,8 @@ body::after {
   0%, 100% { opacity: 1; }
   50%       { opacity: 0; }
 }
+
+@keyframes activity-scan {
+  0%   { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "RemoCoder",
     "slug": "remocoder",
     "scheme": "remocoder",
-    "version": "0.0.13",
+    "version": "0.1.0",
     "orientation": "portrait",
     "userInterfaceStyle": "dark",
     "ios": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/mobile",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/mobile/src/__mocks__/async-storage.ts
+++ b/packages/mobile/src/__mocks__/async-storage.ts
@@ -15,6 +15,10 @@ const AsyncStorage = {
   setItem: jest.fn(async (key: string, value: string) => {
     store[key] = value
   }),
+  multiGet: jest.fn(async (keys: string[]) =>
+    keys.map((k) => [k, store[k] ?? null] as [string, string | null])
+  ),
+  removeItem: jest.fn(async (key: string) => { delete store[key] }),
   clear: jest.fn(async () => {
     Object.keys(store).forEach((k) => delete store[k])
   }),

--- a/packages/mobile/src/hooks/useSessionPickerWs.ts
+++ b/packages/mobile/src/hooks/useSessionPickerWs.ts
@@ -83,10 +83,10 @@ export function useSessionPickerWs(ip: string, token: string, profileId: string 
             })
           }
         } else if (msg.type === 'session_list') {
-          queryClient.setQueryData(sessionPickerKeys.sessions(ip, token), {
+          queryClient.setQueryData(sessionPickerKeys.sessions(ip, token), (old: SessionsData | undefined) => ({
             sessions: msg.sessions,
-            multiplexerSessions: msg.multiplexerSessions ?? [],
-          } satisfies SessionsData)
+            multiplexerSessions: msg.multiplexerSessions ?? old?.multiplexerSessions ?? [],
+          } satisfies SessionsData))
         } else if (msg.type === 'project_list') {
           queryClient.setQueryData(sessionPickerKeys.projects(ip, token), msg.projects)
         } else if (msg.type === 'session_deleted') {

--- a/packages/mobile/src/screens/SessionPickerScreen.tsx
+++ b/packages/mobile/src/screens/SessionPickerScreen.tsx
@@ -13,29 +13,11 @@ import {
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { MultiplexerSessionInfo, ProjectInfo, SessionInfo, SessionSource, sessionSourceIcon } from '@remocoder/shared'
+import { MultiplexerSessionInfo, ProjectInfo, SessionInfo, SessionSource, sessionSourceIcon, sessionProjectName, formatSessionElapsed } from '@remocoder/shared'
 import { firstParam, formatDate, getSessionDisplayName } from '../utils'
 import { useSessionPickerWs } from '../hooks/useSessionPickerWs'
 
 // ── モバイル用ヘルパー ──────────────────────────────────────────────────────
-
-function mobileProjectName(session: SessionInfo): string | undefined {
-  const path =
-    (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
-    session.projectPath
-  if (!path) return undefined
-  return path.split('/').filter(Boolean).pop()
-}
-
-function mobileFormatElapsed(isoString: string): string {
-  const ms = Date.now() - new Date(isoString).getTime()
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s ago`
-  const m = Math.floor(s / 60)
-  if (m < 60) return `${m} min ago`
-  const h = Math.floor(m / 60)
-  return `${h} hr ago`
-}
 
 function mobilePhaseBadgeText(phase?: SessionInfo['claudePhase']): string | null {
   switch (phase) {
@@ -308,7 +290,7 @@ export function SessionPickerScreen() {
             if (item.kind === 'session') {
               const { session } = item
               const label = labels[session.id]
-              const projectName = mobileProjectName(session)
+              const projectName = sessionProjectName(session)
               const displayName = label || projectName || getSessionDisplayName(session)
               const icon = sessionSourceIcon(session.source)
               const phaseBadge = mobilePhaseBadgeText(session.claudePhase)
@@ -336,7 +318,7 @@ export function SessionPickerScreen() {
                     <Text style={styles.sessionMeta}>
                       {session.status === 'active' ? 'Active' : 'Idle'}
                       {session.hasClient ? ' · Connected' : ''}
-                      {' · '}{mobileFormatElapsed(session.createdAt)}
+                      {' · '}{formatSessionElapsed(session.createdAt)}
                     </Text>
                     {session.lastOutputLine && (
                       <Text style={mobileSessionStyles.outputPreview} numberOfLines={1}>

--- a/packages/mobile/src/screens/SessionPickerScreen.tsx
+++ b/packages/mobile/src/screens/SessionPickerScreen.tsx
@@ -13,23 +13,11 @@ import {
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { MultiplexerSessionInfo, ProjectInfo, SessionInfo, SessionSource } from '@remocoder/shared'
+import { MultiplexerSessionInfo, ProjectInfo, SessionInfo, SessionSource, sessionSourceIcon } from '@remocoder/shared'
 import { firstParam, formatDate, getSessionDisplayName } from '../utils'
 import { useSessionPickerWs } from '../hooks/useSessionPickerWs'
 
 // ── モバイル用ヘルパー ──────────────────────────────────────────────────────
-
-function mobileSourceIcon(source?: SessionSource): string {
-  if (!source) return '🖥'
-  switch (source.kind) {
-    case 'claude': return '🤖'
-    case 'shell':  return '🐚'
-    case 'tmux':   return '📟'
-    case 'screen': return '🖥'
-    case 'zellij': return '🪟'
-    default:       return '🖥'
-  }
-}
 
 function mobileProjectName(session: SessionInfo): string | undefined {
   const path =
@@ -322,7 +310,7 @@ export function SessionPickerScreen() {
               const label = labels[session.id]
               const projectName = mobileProjectName(session)
               const displayName = label || projectName || getSessionDisplayName(session)
-              const icon = mobileSourceIcon(session.source)
+              const icon = sessionSourceIcon(session.source)
               const phaseBadge = mobilePhaseBadgeText(session.claudePhase)
               const isDeleting = isDeletingSession && deletingSessionId === session.id
               return (

--- a/packages/mobile/src/screens/SessionPickerScreen.tsx
+++ b/packages/mobile/src/screens/SessionPickerScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import {
   View,
   Text,
@@ -7,12 +7,154 @@ import {
   StyleSheet,
   ActivityIndicator,
   Alert,
+  TextInput,
 } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { MultiplexerSessionInfo, ProjectInfo, SessionInfo, SessionSource } from '@remocoder/shared'
 import { firstParam, formatDate, getSessionDisplayName } from '../utils'
 import { useSessionPickerWs } from '../hooks/useSessionPickerWs'
+
+// ── モバイル用ヘルパー ──────────────────────────────────────────────────────
+
+function mobileSourceIcon(source?: SessionSource): string {
+  if (!source) return '🖥'
+  switch (source.kind) {
+    case 'claude': return '🤖'
+    case 'shell':  return '🐚'
+    case 'tmux':   return '📟'
+    case 'screen': return '🖥'
+    case 'zellij': return '🪟'
+    default:       return '🖥'
+  }
+}
+
+function mobileProjectName(session: SessionInfo): string | undefined {
+  const path =
+    (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
+    session.projectPath
+  if (!path) return undefined
+  return path.split('/').filter(Boolean).pop()
+}
+
+function mobileFormatElapsed(isoString: string): string {
+  const ms = Date.now() - new Date(isoString).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} min ago`
+  const h = Math.floor(m / 60)
+  return `${h} hr ago`
+}
+
+function mobilePhaseBadgeText(phase?: SessionInfo['claudePhase']): string | null {
+  switch (phase) {
+    case 'thinking': return '✦ THINKING'
+    case 'writing':  return '✦ WRITING'
+    case 'waiting':  return '? WAITING'
+    default:         return null
+  }
+}
+
+const LABEL_KEY_PREFIX = 'session-label-'
+
+function useMobileLabels(sessionIds: string[]) {
+  const [labels, setLabels] = React.useState<Record<string, string>>({})
+
+  useEffect(() => {
+    if (sessionIds.length === 0) return
+    const keys = sessionIds.map((id) => LABEL_KEY_PREFIX + id)
+    AsyncStorage.multiGet(keys).then((pairs) => {
+      const map: Record<string, string> = {}
+      pairs.forEach(([key, value]) => {
+        if (value) map[key.replace(LABEL_KEY_PREFIX, '')] = value
+      })
+      setLabels(map)
+    })
+  }, [sessionIds.join(',')])
+
+  const setLabel = async (sessionId: string, label: string) => {
+    if (label.trim()) {
+      await AsyncStorage.setItem(LABEL_KEY_PREFIX + sessionId, label.trim())
+      setLabels((prev) => ({ ...prev, [sessionId]: label.trim() }))
+    } else {
+      await AsyncStorage.removeItem(LABEL_KEY_PREFIX + sessionId)
+      setLabels((prev) => { const next = { ...prev }; delete next[sessionId]; return next })
+    }
+  }
+
+  return { labels, setLabel }
+}
+
+function RenameModal({
+  visible,
+  initialValue,
+  onConfirm,
+  onCancel,
+}: {
+  visible: boolean
+  initialValue: string
+  onConfirm: (value: string) => void
+  onCancel: () => void
+}) {
+  const [value, setValue] = React.useState(initialValue)
+
+  useEffect(() => {
+    if (visible) setValue(initialValue)
+  }, [visible, initialValue])
+
+  if (!visible) return null
+
+  return (
+    <View style={renameStyles.overlay}>
+      <View style={renameStyles.modal}>
+        <Text style={renameStyles.title}>Rename Session</Text>
+        <TextInput
+          style={renameStyles.input}
+          value={value}
+          onChangeText={setValue}
+          placeholder="Session name"
+          placeholderTextColor="#8b949e"
+          autoFocus
+          selectTextOnFocus
+        />
+        <View style={renameStyles.buttons}>
+          <TouchableOpacity style={renameStyles.cancelBtn} onPress={onCancel}>
+            <Text style={renameStyles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={renameStyles.confirmBtn} onPress={() => onConfirm(value)}>
+            <Text style={renameStyles.confirmText}>Save</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const renameStyles = StyleSheet.create({
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    alignItems: 'center', justifyContent: 'center', zIndex: 100,
+  },
+  modal: {
+    backgroundColor: '#161b22', borderRadius: 12, padding: 20,
+    width: '80%', borderWidth: 1, borderColor: 'rgba(255,255,255,0.1)',
+    gap: 14,
+  },
+  title: { color: '#c9d1d9', fontSize: 16, fontWeight: '600' },
+  input: {
+    backgroundColor: '#0d1117', borderWidth: 1, borderColor: 'rgba(255,255,255,0.15)',
+    borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+    color: '#c9d1d9', fontSize: 14,
+  },
+  buttons: { flexDirection: 'row', gap: 10, justifyContent: 'flex-end' },
+  cancelBtn: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 6, backgroundColor: 'rgba(255,255,255,0.06)' },
+  cancelText: { color: '#8b949e', fontSize: 14 },
+  confirmBtn: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 6, backgroundColor: 'rgba(78,201,176,0.15)', borderWidth: 1, borderColor: 'rgba(78,201,176,0.3)' },
+  confirmText: { color: '#4ec9b0', fontSize: 14, fontWeight: '600' },
+})
 
 type ListItem =
   | { kind: 'header'; label: string }
@@ -40,6 +182,11 @@ export function SessionPickerScreen() {
     selectedRef,
   } = useSessionPickerWs(ip, token, profileId ?? null)
 
+  const sessionIds = useMemo(() => sessions.map((s) => s.id), [sessions])
+  const { labels, setLabel } = useMobileLabels(sessionIds)
+
+  const [renameTarget, setRenameTarget] = React.useState<{ id: string; current: string } | null>(null)
+
   const navigateToTerminal = useCallback(
     (params: Record<string, string>) => {
       selectedRef.current = true
@@ -59,23 +206,37 @@ export function SessionPickerScreen() {
     [navigateToTerminal],
   )
 
-  const handleDeleteSession = useCallback(
+  const handleLongPressSession = useCallback(
     (session: SessionInfo) => {
-      const name = getSessionDisplayName(session)
+      if (isDeletingSession) return
+      const name = labels[session.id] || getSessionDisplayName(session)
       Alert.alert(
-        'Delete Session',
-        `Terminate and delete "${name}"?`,
+        name,
+        'Choose an action',
         [
-          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Rename',
+            onPress: () => setRenameTarget({ id: session.id, current: labels[session.id] ?? '' }),
+          },
           {
             text: 'Delete',
             style: 'destructive',
-            onPress: () => deleteSession(session.id),
+            onPress: () => {
+              Alert.alert(
+                'Delete Session',
+                `Terminate and delete "${name}"?`,
+                [
+                  { text: 'Cancel', style: 'cancel' },
+                  { text: 'Delete', style: 'destructive', onPress: () => deleteSession(session.id) },
+                ],
+              )
+            },
           },
+          { text: 'Cancel', style: 'cancel' },
         ],
       )
     },
-    [deleteSession],
+    [isDeletingSession, labels, deleteSession],
   )
 
   const handleAttachMultiplexer = (mux: MultiplexerSessionInfo) => {
@@ -155,13 +316,17 @@ export function SessionPickerScreen() {
             }
             if (item.kind === 'session') {
               const { session } = item
-              const name = getSessionDisplayName(session)
+              const label = labels[session.id]
+              const projectName = mobileProjectName(session)
+              const displayName = label || projectName || getSessionDisplayName(session)
+              const icon = mobileSourceIcon(session.source)
+              const phaseBadge = mobilePhaseBadgeText(session.claudePhase)
               const isDeleting = isDeletingSession && deletingSessionId === session.id
               return (
                 <TouchableOpacity
                   style={[styles.sessionRow, isDeleting && styles.sessionRowDeleting]}
                   onPress={() => !isDeleting && handleAttachSession(session.id)}
-                  onLongPress={() => !isDeleting && handleDeleteSession(session)}
+                  onLongPress={() => !isDeleting && handleLongPressSession(session)}
                   delayLongPress={500}
                 >
                   <View
@@ -171,16 +336,22 @@ export function SessionPickerScreen() {
                     ]}
                   />
                   <View style={styles.sessionInfo}>
-                    <Text style={styles.sessionName}>{name}</Text>
-                    {session.projectPath && (
-                      <Text style={styles.sessionPath} numberOfLines={1} ellipsizeMode="middle">
-                        {session.projectPath}
-                      </Text>
-                    )}
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                      <Text style={styles.sessionName}>{icon} {displayName}</Text>
+                      {phaseBadge && (
+                        <Text style={mobileSessionStyles.phaseBadge}>{phaseBadge}</Text>
+                      )}
+                    </View>
                     <Text style={styles.sessionMeta}>
                       {session.status === 'active' ? 'Active' : 'Idle'}
                       {session.hasClient ? ' · Connected' : ''}
+                      {' · '}{mobileFormatElapsed(session.createdAt)}
                     </Text>
+                    {session.lastOutputLine && (
+                      <Text style={mobileSessionStyles.outputPreview} numberOfLines={1}>
+                        ▸ {session.lastOutputLine}
+                      </Text>
+                    )}
                   </View>
                   {isDeleting
                     ? <ActivityIndicator size="small" color="#f85149" />
@@ -233,6 +404,15 @@ export function SessionPickerScreen() {
           }}
         />
       )}
+      <RenameModal
+        visible={renameTarget !== null}
+        initialValue={renameTarget?.current ?? ''}
+        onConfirm={(value) => {
+          if (renameTarget) setLabel(renameTarget.id, value)
+          setRenameTarget(null)
+        }}
+        onCancel={() => setRenameTarget(null)}
+      />
     </SafeAreaView>
   )
 }
@@ -407,5 +587,20 @@ const styles = StyleSheet.create({
     color: '#8b949e',
     fontSize: 11,
     flexShrink: 0,
+  },
+})
+
+const mobileSessionStyles = StyleSheet.create({
+  phaseBadge: {
+    color: '#60a5fa',
+    fontSize: 10,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+  },
+  outputPreview: {
+    color: '#4ec9b0',
+    fontSize: 11,
+    fontFamily: 'monospace',
+    marginTop: 2,
   },
 })

--- a/packages/mobile/src/screens/SessionPickerScreen.tsx
+++ b/packages/mobile/src/screens/SessionPickerScreen.tsx
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
   Alert,
   TextInput,
+  Modal,
 } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -61,6 +62,8 @@ const LABEL_KEY_PREFIX = 'session-label-'
 
 function useMobileLabels(sessionIds: string[]) {
   const [labels, setLabels] = React.useState<Record<string, string>>({})
+  // セッションIDのセットが変わった時のみ再フェッチ（順序に依存しないよう sort）
+  const sortedIdsKey = useMemo(() => [...sessionIds].sort().join(','), [sessionIds])
 
   useEffect(() => {
     if (sessionIds.length === 0) return
@@ -72,7 +75,7 @@ function useMobileLabels(sessionIds: string[]) {
       })
       setLabels(map)
     })
-  }, [sessionIds.join(',')])
+  }, [sortedIdsKey])
 
   const setLabel = async (sessionId: string, label: string) => {
     if (label.trim()) {
@@ -104,39 +107,39 @@ function RenameModal({
     if (visible) setValue(initialValue)
   }, [visible, initialValue])
 
-  if (!visible) return null
-
   return (
-    <View style={renameStyles.overlay}>
-      <View style={renameStyles.modal}>
-        <Text style={renameStyles.title}>Rename Session</Text>
-        <TextInput
-          style={renameStyles.input}
-          value={value}
-          onChangeText={setValue}
-          placeholder="Session name"
-          placeholderTextColor="#8b949e"
-          autoFocus
-          selectTextOnFocus
-        />
-        <View style={renameStyles.buttons}>
-          <TouchableOpacity style={renameStyles.cancelBtn} onPress={onCancel}>
-            <Text style={renameStyles.cancelText}>Cancel</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={renameStyles.confirmBtn} onPress={() => onConfirm(value)}>
-            <Text style={renameStyles.confirmText}>Save</Text>
-          </TouchableOpacity>
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      <View style={renameStyles.overlay}>
+        <View style={renameStyles.modal}>
+          <Text style={renameStyles.title}>Rename Session</Text>
+          <TextInput
+            style={renameStyles.input}
+            value={value}
+            onChangeText={setValue}
+            placeholder="Session name"
+            placeholderTextColor="#8b949e"
+            autoFocus
+            selectTextOnFocus
+          />
+          <View style={renameStyles.buttons}>
+            <TouchableOpacity style={renameStyles.cancelBtn} onPress={onCancel}>
+              <Text style={renameStyles.cancelText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={renameStyles.confirmBtn} onPress={() => onConfirm(value)}>
+              <Text style={renameStyles.confirmText}>Save</Text>
+            </TouchableOpacity>
+          </View>
         </View>
       </View>
-    </View>
+    </Modal>
   )
 }
 
 const renameStyles = StyleSheet.create({
   overlay: {
-    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    flex: 1,
     backgroundColor: 'rgba(0,0,0,0.7)',
-    alignItems: 'center', justifyContent: 'center', zIndex: 100,
+    alignItems: 'center', justifyContent: 'center',
   },
   modal: {
     backgroundColor: '#161b22', borderRadius: 12, padding: 20,

--- a/packages/mobile/src/screens/__tests__/SessionPickerScreen.test.tsx
+++ b/packages/mobile/src/screens/__tests__/SessionPickerScreen.test.tsx
@@ -89,7 +89,7 @@ describe('SessionPickerScreen', () => {
     triggerMessage({ type: 'project_list', projects: [] })
 
     await waitFor(() => expect(screen.getByText('Active Sessions')).toBeTruthy())
-    expect(screen.getByText('myapp')).toBeTruthy()
+    expect(screen.getByText('myapp', { exact: false })).toBeTruthy()
   })
 
   it('project_list を受信すると「新規セッション」セクションにプロジェクトが表示される', async () => {
@@ -117,8 +117,8 @@ describe('SessionPickerScreen', () => {
     })
     triggerMessage({ type: 'project_list', projects: [] })
 
-    await waitFor(() => expect(screen.getByText('myapp')).toBeTruthy())
-    fireEvent.press(screen.getByText('myapp'))
+    await waitFor(() => expect(screen.getByText('myapp', { exact: false })).toBeTruthy())
+    fireEvent.press(screen.getByText('myapp', { exact: false }))
 
     expect(mockRouterPush).toHaveBeenCalledWith({
       pathname: '/terminal',
@@ -238,7 +238,7 @@ describe('SessionPickerScreen', () => {
     })
     triggerMessage({ type: 'project_list', projects: [] })
 
-    await waitFor(() => expect(screen.getByText('Active')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(/^Active\b(?! Sessions)/, { exact: false })).toBeTruthy())
   })
 
   it('セッションの hasClient が true のとき「· 接続中」と表示される', async () => {
@@ -253,7 +253,7 @@ describe('SessionPickerScreen', () => {
     })
     triggerMessage({ type: 'project_list', projects: [] })
 
-    await waitFor(() => expect(screen.getByText('Active · Connected')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('Active · Connected', { exact: false })).toBeTruthy())
   })
 
   describe('セッション削除', () => {
@@ -266,18 +266,34 @@ describe('SessionPickerScreen', () => {
       triggerMessage({ type: 'auth_ok' })
       triggerMessage({ type: 'session_list', sessions: [session] })
       triggerMessage({ type: 'project_list', projects: [] })
-      await waitFor(() => expect(screen.getByText('app')).toBeTruthy())
+      await waitFor(() => expect(screen.getByText('app', { exact: false })).toBeTruthy())
     }
 
-    function confirmDelete() {
-      // Alert.alert に渡されたボタン定義から「削除」ボタンの onPress を呼ぶ
-      const [, , buttons] = Alert.alert.mock.lastCall
-      buttons.find((b: { text: string; onPress?: () => void }) => b.text === 'Delete')?.onPress?.()
+    function pressDeleteInActionSheet() {
+      // ステップ1: アクションシートの「Delete」ボタンを押して確認 Alert を表示する
+      const firstCallButtons = Alert.alert.mock.calls[Alert.alert.mock.calls.length - 1][2]
+      firstCallButtons.find((b: { text: string; onPress?: () => void }) => b.text === 'Delete')?.onPress?.()
+    }
+
+    function confirmDeleteInConfirmation() {
+      // ステップ2: 確認 Alert の「Delete」ボタンを押して削除を実行する
+      const lastCallButtons = Alert.alert.mock.calls[Alert.alert.mock.calls.length - 1][2]
+      lastCallButtons.find((b: { text: string; onPress?: () => void }) => b.text === 'Delete')?.onPress?.()
     }
 
     it('ロングプレスで Alert が表示され、確認すると session_delete を送信する', async () => {
       await renderWithSession()
-      fireEvent(screen.getByText('app'), 'longPress')
+      fireEvent(screen.getByText('app', { exact: false }), 'longPress')
+
+      // ステップ1: アクションシート Alert が表示される
+      expect(Alert.alert).toHaveBeenCalledWith(
+        expect.any(String),
+        'Choose an action',
+        expect.any(Array),
+      )
+
+      // ステップ2: アクションシートの「Delete」を押すと確認 Alert が表示される
+      act(() => pressDeleteInActionSheet())
 
       expect(Alert.alert).toHaveBeenCalledWith(
         'Delete Session',
@@ -285,7 +301,8 @@ describe('SessionPickerScreen', () => {
         expect.any(Array),
       )
 
-      act(() => confirmDelete())
+      // ステップ3: 確認 Alert の「Delete」を押すと session_delete が送信される
+      act(() => confirmDeleteInConfirmation())
 
       await waitFor(() =>
         expect(mockWs.send).toHaveBeenCalledWith(
@@ -296,20 +313,21 @@ describe('SessionPickerScreen', () => {
 
     it('session_deleted 受信でセッション行がリストから消える', async () => {
       await renderWithSession()
-      fireEvent(screen.getByText('app'), 'longPress')
-      act(() => confirmDelete())
+      fireEvent(screen.getByText('app', { exact: false }), 'longPress')
+      act(() => pressDeleteInActionSheet())
+      act(() => confirmDeleteInConfirmation())
 
       triggerMessage({ type: 'session_deleted', sessionId: 'sid-del' })
 
-      await waitFor(() => expect(screen.queryByText('app')).toBeNull(), { timeout: 5000 })
+      await waitFor(() => expect(screen.queryByText('app', { exact: false })).toBeNull(), { timeout: 5000 })
     })
 
     it('キャンセルを選ぶと session_delete は送信されない', async () => {
       await renderWithSession()
       mockWs.send.mockClear()
-      fireEvent(screen.getByText('app'), 'longPress')
+      fireEvent(screen.getByText('app', { exact: false }), 'longPress')
 
-      // キャンセルボタンの onPress は undefined（style: 'cancel'）なので送信されない
+      // アクションシートの「Cancel」を押す（onPress は undefined のため何も起きない）
       const [, , buttons] = Alert.alert.mock.lastCall
       buttons.find((b: { text: string; onPress?: () => void }) => b.text === 'Cancel')?.onPress?.()
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -84,6 +84,24 @@ export interface SessionInfo {
 
 export const DEFAULT_WS_PORT = 8080
 
+export function sessionProjectName(session: SessionInfo): string | undefined {
+  const path =
+    (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
+    session.projectPath
+  if (!path) return undefined
+  return path.split('/').filter(Boolean).pop()
+}
+
+export function formatSessionElapsed(isoString: string): string {
+  const ms = Date.now() - new Date(isoString).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} min ago`
+  const h = Math.floor(m / 60)
+  return `${h} hr ago`
+}
+
 export function sessionSourceIcon(source?: SessionSource): string {
   if (!source) return '🖥'
   switch (source.kind) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -89,7 +89,7 @@ export function sessionProjectName(session: SessionInfo): string | undefined {
     (session.source?.kind === 'claude' ? session.source.projectPath : undefined) ??
     session.projectPath
   if (!path) return undefined
-  return path.split('/').filter(Boolean).pop()
+  return path.split(/[/\\]/).filter(Boolean).pop()
 }
 
 export function formatSessionElapsed(isoString: string): string {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -74,6 +74,12 @@ export interface SessionInfo {
   projectPath?: string
   /** セッションの起動元 */
   source?: SessionSource
+  /** PTYへの最終出力時刻 (ISO 8601) */
+  lastActiveAt?: string
+  /** PTYの最終出力行（ANSI除去済み、最大80文字） */
+  lastOutputLine?: string
+  /** Claudeの処理フェーズ推定 */
+  claudePhase?: 'thinking' | 'writing' | 'waiting' | 'idle'
 }
 
 export const DEFAULT_WS_PORT = 8080

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -84,6 +84,18 @@ export interface SessionInfo {
 
 export const DEFAULT_WS_PORT = 8080
 
+export function sessionSourceIcon(source?: SessionSource): string {
+  if (!source) return '🖥'
+  switch (source.kind) {
+    case 'claude': return '🤖'
+    case 'shell':  return '🐚'
+    case 'tmux':   return '📟'
+    case 'screen': return '🖥'
+    case 'zellij': return '🪟'
+    default:       return '🖥'
+  }
+}
+
 /** スリープ抑制設定 */
 export interface PowerSettings {
   /** AC電源（充電中）のときにスリープを抑制する */


### PR DESCRIPTION
## Summary

- **shared**: `SessionInfo` に `lastActiveAt` / `lastOutputLine` / `claudePhase` を追加
- **desktop (pty-server)**: PTY 出力から Claude フェーズ（thinking / writing / waiting / idle）を推定し、最終出力行・最終アクティブ時刻を追跡。フェーズ変更時のみ `notifySessions()` を呼ぶよう最適化
- **desktop (SessionList)**: Rich Card 形式へ刷新。ソース種別アイコン・プロジェクト名・経過時間・フェーズバッジ・アクティビティバー・出力プレビュー・インラインラベル編集（localStorage 永続化）を追加
- **mobile (SessionPickerScreen)**: 同等の情報を表示。カスタムラベル（AsyncStorage）・RenameModal・長押しメニュー（Rename / Delete）を追加

## Test Plan

- [ ] Desktop: `cd packages/desktop && npx vitest run` → 178 件 PASS
- [ ] Mobile: `cd packages/mobile && npx jest --passWithNoTests` → 124 件 PASS
- [ ] Desktop アプリを起動してセッション一覧に Rich Card が表示されることを確認
- [ ] Claude セッションで出力が発生すると、フェーズバッジと出力プレビューが更新されることを確認
- [ ] セッション名をクリックしてインライン編集できることを確認（再起動後も保持されること）
- [ ] Mobile でセッション長押し → Rename / Delete メニューが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)