### PR TITLE
fix(desktop): mobile からの session_create でも tmux セッションを重複作成しない

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./out/main/index.js",

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -761,7 +761,15 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
         }
         const source = rawSource as SessionSource
         pickerSockets.delete(ws)
-        const session = createPtySession(source, clientIP)
+        // マルチプレクサは同名セッションが既存なら再利用する（Desktop と同じ挙動）
+        const existingMux = isMultiplexer
+          ? Array.from(ptySessions.values()).find(
+              (s) => s.source?.kind === source.kind &&
+                (s.source as Extract<SessionSource, { sessionName: string }>).sessionName ===
+                (source as Extract<SessionSource, { sessionName: string }>).sessionName,
+            )
+          : undefined
+        const session = existingMux ?? createPtySession(source, clientIP)
         attachedSessionId = session.id
         session.wsClient = ws
         session.clientIP = clientIP

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -770,6 +770,20 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
             )
           : undefined
         const session = existingMux ?? createPtySession(source, clientIP)
+        // 既存セッションを再利用する場合は session_attach と同じ手順で安全にアタッチする
+        if (existingMux) {
+          if (existingMux.detachCleanupId) {
+            clearTimeout(existingMux.detachCleanupId)
+            existingMux.detachCleanupId = null
+          }
+          if (
+            existingMux.wsClient &&
+            existingMux.wsClient !== ws &&
+            existingMux.wsClient.readyState === WebSocket.OPEN
+          ) {
+            existingMux.wsClient.close()
+          }
+        }
         attachedSessionId = session.id
         session.wsClient = ws
         session.clientIP = clientIP
@@ -778,7 +792,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
           JSON.stringify({
             type: 'session_attached',
             sessionId: session.id,
-            scrollback: '',
+            scrollback: existingMux ? getScrollback(session) : '',
             source: session.source,
           } satisfies WsMessage),
         )

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "RemoCoder",
     "slug": "remocoder",
     "scheme": "remocoder",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "orientation": "portrait",
     "userInterfaceStyle": "dark",
     "ios": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/mobile",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Closes #125

## Summary

- `session_create` メッセージハンドラー（Mobile 経由）に、`desktopCreateSession` と同じマルチプレクサセッション重複チェックを追加
- 同じ `kind` + `sessionName` の PtySession が既存なら新規作成せず再利用する

## Root Cause

`desktopCreateSession`（Desktop UI 経由）は tmux / screen / zellij の同名セッションを検索して既存 PtySession を返していたが、Mobile から送られる `session_create` メッセージのハンドラーは `createPtySession` を直接呼んでおり、重複チェックをスキップしていた。

## Test Plan

- [ ] `cd packages/desktop && npx vitest run` → 46件 PASS
- [ ] モバイルから同じ tmux セッションを複数回選択しても ACTIVE SESSIONS が増えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)