### PR TITLE
fix(desktop): BrowserWindow 破棄後の IPC 送信で「Object has been destroyed」クラッシュを修正

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "main": "./out/main/index.js",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -116,6 +116,9 @@ function createWindow(icon: Electron.NativeImage | null) {
       win?.hide()
     }
   })
+  win.on('closed', () => {
+    win = null
+  })
 }
 
 function resizeWindow(size: { width: number; height: number }): void {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -274,16 +274,22 @@ app.whenReady().then(async () => {
 
   initToken(loadOrCreateToken())
 
+  const sendToRenderer = (channel: string, ...args: unknown[]) => {
+    if (win && !win.isDestroyed() && !win.webContents.isDestroyed()) {
+      win.webContents.send(channel, ...args)
+    }
+  }
+
   const { wss, getToken } = startPtyServer(undefined, {
     onSessionsChange: (sessions) => {
       currentSessions = sessions
-      win?.webContents.send('sessions-update', sessions)
+      sendToRenderer('sessions-update', sessions)
     },
     onPtyOutput: (sessionId, data) => {
-      win?.webContents.send('pty-output', { sessionId, data })
+      sendToRenderer('pty-output', { sessionId, data })
     },
     onPtyExit: (sessionId, exitCode) => {
-      win?.webContents.send('pty-exit', { sessionId, exitCode })
+      sendToRenderer('pty-exit', { sessionId, exitCode })
     },
   })
 

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "RemoCoder",
     "slug": "remocoder",
     "scheme": "remocoder",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "orientation": "portrait",
     "userInterfaceStyle": "dark",
     "ios": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remocoder/mobile",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- シャットダウン中にタイマーが発火して `notifySessions` が呼ばれると、すでに破棄された `BrowserWindow` の `webContents` に IPC 送信してクラッシュしていた問題を修正
- `sendToRenderer` ヘルパーを追加し、`isDestroyed()` チェックを通過した場合のみ送信するように変更
- 開発ビルドで顕在化しやすいが、本番ビルドのシャットダウン中も同様に発生しうるため共通修正として適用

Closes #127

## Test plan

- [ ] 開発ビルドでウィンドウを閉じてもクラッシュしないことを確認
- [ ] セッション一覧の更新が通常時も正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)