### PR TITLE
feat: herdr マルチプレクサ対応を追加

### DIFF
--- a/packages/desktop/src/main/exec-env.ts
+++ b/packages/desktop/src/main/exec-env.ts
@@ -1,10 +1,15 @@
 import { exec } from 'child_process'
+import { homedir } from 'os'
+import { join } from 'path'
 import { promisify } from 'util'
 
 // パッケージ化アプリは .zshrc 等を読まず PATH が限定されるため明示的に指定する
+const home = homedir()
 export const EXEC_ENV = {
   ...process.env,
   PATH: [
+    join(home, '.local/bin'),
+    join(home, '.cargo/bin'),
     '/usr/local/bin',
     '/opt/homebrew/bin',
     '/usr/bin',

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -197,7 +197,7 @@ function setupIpc(getToken: () => string) {
     return desktopCreateSession(source)
   })
 
-  /** tmux / screen / zellij のセッション一覧を返す */
+  /** tmux / screen / zellij / herdr のセッション一覧を返す */
   ipcMain.handle('get-multiplexer-sessions', () => {
     return getMultiplexerSessions()
   })

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -197,7 +197,7 @@ function setupIpc(getToken: () => string) {
     return desktopCreateSession(source)
   })
 
-  /** tmux / screen / zellij / herdr のセッション一覧を返す */
+  /** マルチプレクサのセッション一覧を返す */
   ipcMain.handle('get-multiplexer-sessions', () => {
     return getMultiplexerSessions()
   })

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -4,7 +4,7 @@ import type { IncomingMessage } from 'http'
 import { existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir, hostname as osHostname } from 'os'
-import { WsMessage, SessionInfo, ProjectInfo, MultiplexerSessionInfo, SessionSource, DEFAULT_WS_PORT } from '@remocoder/shared'
+import { WsMessage, SessionInfo, ProjectInfo, MultiplexerSessionInfo, SessionSource, DEFAULT_WS_PORT, MULTIPLEXER_KINDS, isMultiplexerKind, isMultiplexerSource } from '@remocoder/shared'
 import { v4 as uuidv4 } from 'uuid'
 import { tryParsePermission, stripAnsi } from './permission-parser'
 import { execAsync, EXEC_ENV } from './exec-env'
@@ -517,7 +517,7 @@ function createExternalSession(providerWs: WebSocket): PtySession {
 /** デスクトップから新規PTYセッションを作成する */
 export function desktopCreateSession(source: SessionSource = { kind: 'claude' }): string {
   // マルチプレクサの場合、同じセッションにアタッチ済みのPTYセッションがあれば再利用する
-  if (source.kind === 'tmux' || source.kind === 'screen' || source.kind === 'zellij' || source.kind === 'herdr') {
+  if (isMultiplexerSource(source)) {
     const { kind, sessionName } = source
     const existing = Array.from(ptySessions.values()).find(
       (s) => s.source?.kind === kind && (s.source as typeof source).sessionName === sessionName,
@@ -749,11 +749,12 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
         detachFromSession()
         // source が指定されていればそれを使用、なければ後方互換で claude として扱う
         const rawSource = msg.source ?? { kind: 'claude', projectPath: msg.projectPath }
-        const allowedKinds = ['claude', 'tmux', 'screen', 'zellij', 'herdr', 'shell'] as const
-        const isMultiplexer = rawSource.kind === 'tmux' || rawSource.kind === 'screen' || rawSource.kind === 'zellij' || rawSource.kind === 'herdr'
+        const allowedKinds = ['claude', ...MULTIPLEXER_KINDS, 'shell'] as const
+        const isMultiplexer = isMultiplexerKind(rawSource.kind)
+        const rawName = (rawSource as Record<string, unknown>).sessionName
         const isInvalid =
           !allowedKinds.includes(rawSource.kind as (typeof allowedKinds)[number]) ||
-          (isMultiplexer && (typeof rawSource.sessionName !== 'string' || rawSource.sessionName.length === 0))
+          (isMultiplexer && (typeof rawName !== 'string' || rawName.length === 0))
         if (isInvalid) {
           console.warn(`[pty-server] Rejected session_create: invalid source ${JSON.stringify(rawSource)}`)
           ws.send(JSON.stringify({ type: 'auth_error', reason: 'invalid session source' } satisfies WsMessage))
@@ -1025,10 +1026,9 @@ function spawnSource(source: SessionSource): pty.IPty {
 export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]> {
   const results: MultiplexerSessionInfo[] = []
 
-  // tmux
-  // TERM を明示的に設定することで tmux の vis(3) エンコードを抑制し、
-  // タブ区切り出力が正しく得られるようにする（GUI 起動時は TERM が未設定になる）
-  try {
+  async function collectTmux(): Promise<void> {
+    // TERM を明示的に設定することで tmux の vis(3) エンコードを抑制し、
+    // タブ区切り出力が正しく得られるようにする（GUI 起動時は TERM が未設定になる）
     const { stdout } = await execAsync(
       'tmux list-panes -a -F "#{session_name}\t#{session_windows}\t#{pane_current_path}"',
       { env: { ...EXEC_ENV, TERM: 'xterm-256color' } },
@@ -1048,12 +1048,9 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
         workingDirectory: paneCurrentPath || undefined,
       })
     }
-  } catch {
-    // tmux未インストールまたはセッションなし
   }
 
-  // screen
-  try {
+  async function collectScreen(): Promise<void> {
     // screen -ls は接続中セッションがある場合に exit code 1 を返すため stdout を取り出す
     const screenOutput = await execAsync('screen -ls', { env: EXEC_ENV }).then(
       (r) => r.stdout,
@@ -1067,26 +1064,19 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
         results.push({ tool: 'screen', sessionName, detail: match[2] })
       }
     }
-  } catch {
-    // screen未インストール
   }
 
-  // zellij
-  try {
+  async function collectZellij(): Promise<void> {
     const { stdout } = await execAsync('zellij list-sessions', { env: EXEC_ENV })
     for (const line of stdout.trim().split('\n').filter(Boolean)) {
-      // "session-name [Created...]" 形式の場合もあるため最初のトークンだけ取得
       const sessionName = line.trim().split(/\s+/)[0]
       if (sessionName && SAFE_SESSION_NAME_RE.test(sessionName)) {
         results.push({ tool: 'zellij', sessionName })
       }
     }
-  } catch {
-    // zellij未インストールまたはセッションなし
   }
 
-  // herdr
-  try {
+  async function collectHerdr(): Promise<void> {
     const { stdout } = await execAsync('herdr session list --json', { env: EXEC_ENV })
     const sessions: Array<{ name: string; running: boolean; session_dir?: string }> = JSON.parse(stdout)
     for (const s of sessions) {
@@ -1097,9 +1087,8 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
         detail: s.running ? 'running' : 'stopped',
       })
     }
-  } catch {
-    // herdr未インストールまたはセッションなし
   }
 
+  await Promise.allSettled([collectTmux(), collectScreen(), collectZellij(), collectHerdr()])
   return results
 }

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -983,7 +983,7 @@ function assertSafeSessionName(name: string, tool: string): void {
 }
 
 function spawnSource(source: SessionSource): pty.IPty {
-  const baseOpts = { name: 'xterm-color', cols: 80, rows: 30, env: { ...process.env } }
+  const baseOpts = { name: 'xterm-color', cols: 80, rows: 30, env: { ...EXEC_ENV } }
   switch (source.kind) {
     case 'claude': {
       const loginShell = resolveShell()

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -1025,9 +1025,8 @@ function spawnSource(source: SessionSource): pty.IPty {
 
 /** 利用可能な tmux / screen / zellij / herdr セッション一覧を取得する */
 export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]> {
-  const results: MultiplexerSessionInfo[] = []
-
-  async function collectTmux(): Promise<void> {
+  async function collectTmux(): Promise<MultiplexerSessionInfo[]> {
+    const results: MultiplexerSessionInfo[] = []
     // TERM を明示的に設定することで tmux の vis(3) エンコードを抑制し、
     // タブ区切り出力が正しく得られるようにする（GUI 起動時は TERM が未設定になる）
     const { stdout } = await execAsync(
@@ -1049,9 +1048,11 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
         workingDirectory: paneCurrentPath || undefined,
       })
     }
+    return results
   }
 
-  async function collectScreen(): Promise<void> {
+  async function collectScreen(): Promise<MultiplexerSessionInfo[]> {
+    const results: MultiplexerSessionInfo[] = []
     // screen -ls は接続中セッションがある場合に exit code 1 を返すため stdout を取り出す
     const screenOutput = await execAsync('screen -ls', { env: EXEC_ENV }).then(
       (r) => r.stdout,
@@ -1065,9 +1066,11 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
         results.push({ tool: 'screen', sessionName, detail: match[2] })
       }
     }
+    return results
   }
 
-  async function collectZellij(): Promise<void> {
+  async function collectZellij(): Promise<MultiplexerSessionInfo[]> {
+    const results: MultiplexerSessionInfo[] = []
     const { stdout } = await execAsync('zellij list-sessions', { env: EXEC_ENV })
     for (const line of stdout.trim().split('\n').filter(Boolean)) {
       const sessionName = line.trim().split(/\s+/)[0]
@@ -1075,9 +1078,11 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
         results.push({ tool: 'zellij', sessionName })
       }
     }
+    return results
   }
 
-  async function collectHerdr(): Promise<void> {
+  async function collectHerdr(): Promise<MultiplexerSessionInfo[]> {
+    const results: MultiplexerSessionInfo[] = []
     const { stdout } = await execAsync('herdr session list --json', { env: EXEC_ENV })
     const parsed = JSON.parse(stdout)
     const sessions: Array<{ name: string; running: boolean; session_dir?: string }> =
@@ -1090,8 +1095,9 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
         detail: s.running ? 'running' : 'stopped',
       })
     }
+    return results
   }
 
-  await Promise.allSettled([collectTmux(), collectScreen(), collectZellij(), collectHerdr()])
-  return results
+  const settled = await Promise.allSettled([collectTmux(), collectScreen(), collectZellij(), collectHerdr()])
+  return settled.flatMap((r) => r.status === 'fulfilled' ? r.value : [])
 }

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -769,8 +769,8 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
         const source = rawSource as SessionSource
         pickerSockets.delete(ws)
         // マルチプレクサは同名セッションが既存なら再利用する（Desktop と同じ挙動）
-        const existingMux = isMultiplexer
-          ? findExistingMuxSession(source as MultiplexerSource)
+        const existingMux = isMultiplexerSource(source)
+          ? findExistingMuxSession(source)
           : undefined
         const session = existingMux ?? createPtySession(source, clientIP)
         // 既存セッションを再利用する場合は session_attach と同じ手順で安全にアタッチする

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -1079,7 +1079,9 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
 
   async function collectHerdr(): Promise<void> {
     const { stdout } = await execAsync('herdr session list --json', { env: EXEC_ENV })
-    const sessions: Array<{ name: string; running: boolean; session_dir?: string }> = JSON.parse(stdout)
+    const parsed = JSON.parse(stdout)
+    const sessions: Array<{ name: string; running: boolean; session_dir?: string }> =
+      Array.isArray(parsed) ? parsed : parsed.sessions ?? []
     for (const s of sessions) {
       if (!s.name || !SAFE_SESSION_NAME_RE.test(s.name)) continue
       results.push({

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -517,7 +517,7 @@ function createExternalSession(providerWs: WebSocket): PtySession {
 /** デスクトップから新規PTYセッションを作成する */
 export function desktopCreateSession(source: SessionSource = { kind: 'claude' }): string {
   // マルチプレクサの場合、同じセッションにアタッチ済みのPTYセッションがあれば再利用する
-  if (source.kind === 'tmux' || source.kind === 'screen' || source.kind === 'zellij') {
+  if (source.kind === 'tmux' || source.kind === 'screen' || source.kind === 'zellij' || source.kind === 'herdr') {
     const { kind, sessionName } = source
     const existing = Array.from(ptySessions.values()).find(
       (s) => s.source?.kind === kind && (s.source as typeof source).sessionName === sessionName,
@@ -749,8 +749,8 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
         detachFromSession()
         // source が指定されていればそれを使用、なければ後方互換で claude として扱う
         const rawSource = msg.source ?? { kind: 'claude', projectPath: msg.projectPath }
-        const allowedKinds = ['claude', 'tmux', 'screen', 'zellij', 'shell'] as const
-        const isMultiplexer = rawSource.kind === 'tmux' || rawSource.kind === 'screen' || rawSource.kind === 'zellij'
+        const allowedKinds = ['claude', 'tmux', 'screen', 'zellij', 'herdr', 'shell'] as const
+        const isMultiplexer = rawSource.kind === 'tmux' || rawSource.kind === 'screen' || rawSource.kind === 'zellij' || rawSource.kind === 'herdr'
         const isInvalid =
           !allowedKinds.includes(rawSource.kind as (typeof allowedKinds)[number]) ||
           (isMultiplexer && (typeof rawSource.sessionName !== 'string' || rawSource.sessionName.length === 0))
@@ -1003,6 +1003,11 @@ function spawnSource(source: SessionSource): pty.IPty {
       console.log(`[pty-server] Attaching to zellij session: ${source.sessionName}`)
       return pty.spawn('zellij', ['attach', source.sessionName], baseOpts)
     }
+    case 'herdr': {
+      assertSafeSessionName(source.sessionName, 'herdr')
+      console.log(`[pty-server] Attaching to herdr session: ${source.sessionName}`)
+      return pty.spawn('herdr', ['session', 'attach', source.sessionName], baseOpts)
+    }
     case 'shell': {
       const loginShell = resolveShell()
       const cwd = source.cwd && existsSync(source.cwd) ? source.cwd : undefined
@@ -1016,7 +1021,7 @@ function spawnSource(source: SessionSource): pty.IPty {
 
 // ─── マルチプレクサセッション一覧取得 ────────────────────────────────────────
 
-/** 利用可能な tmux / screen / zellij セッション一覧を取得する */
+/** 利用可能な tmux / screen / zellij / herdr セッション一覧を取得する */
 export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]> {
   const results: MultiplexerSessionInfo[] = []
 
@@ -1078,6 +1083,22 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
     }
   } catch {
     // zellij未インストールまたはセッションなし
+  }
+
+  // herdr
+  try {
+    const { stdout } = await execAsync('herdr session list --json', { env: EXEC_ENV })
+    const sessions: Array<{ name: string; running: boolean; session_dir?: string }> = JSON.parse(stdout)
+    for (const s of sessions) {
+      if (!s.name || !SAFE_SESSION_NAME_RE.test(s.name)) continue
+      results.push({
+        tool: 'herdr',
+        sessionName: s.name,
+        detail: s.running ? 'running' : 'stopped',
+      })
+    }
+  } catch {
+    // herdr未インストールまたはセッションなし
   }
 
   return results

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -4,7 +4,7 @@ import type { IncomingMessage } from 'http'
 import { existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir, hostname as osHostname } from 'os'
-import { WsMessage, SessionInfo, ProjectInfo, MultiplexerSessionInfo, SessionSource, MultiplexerSource, DEFAULT_WS_PORT, MULTIPLEXER_KINDS, isMultiplexerKind, isMultiplexerSource } from '@remocoder/shared'
+import { WsMessage, SessionInfo, ProjectInfo, MultiplexerSessionInfo, SessionSource, MultiplexerSource, MultiplexerKind, DEFAULT_WS_PORT, MULTIPLEXER_KINDS, isMultiplexerKind, isMultiplexerSource } from '@remocoder/shared'
 import { v4 as uuidv4 } from 'uuid'
 import { tryParsePermission, stripAnsi } from './permission-parser'
 import { execAsync, EXEC_ENV } from './exec-env'
@@ -12,6 +12,13 @@ import { execAsync, EXEC_ENV } from './exec-env'
 let AUTH_TOKEN = process.env.REMOTE_TOKEN ?? uuidv4()
 const SERVER_NAME = osHostname()
 const ALLOWED_SOURCE_KINDS = ['claude', ...MULTIPLEXER_KINDS, 'shell'] as const
+
+const MUX_SPAWN_CONFIG: Record<MultiplexerKind, { binary: string; args: (name: string) => string[] }> = {
+  tmux:   { binary: 'tmux',   args: (n) => ['attach-session', '-t', n] },
+  screen: { binary: 'screen', args: (n) => ['-r', n] },
+  zellij: { binary: 'zellij', args: (n) => ['attach', n] },
+  herdr:  { binary: 'herdr',  args: (n) => ['session', 'attach', n] },
+}
 
 // ─── Claude プロジェクト一覧取得 ───────────────────────────────────────────────
 
@@ -169,11 +176,14 @@ interface PtySession {
 const ptySessions = new Map<string, PtySession>()
 
 function findExistingMuxSession(source: MultiplexerSource): PtySession | undefined {
-  return Array.from(ptySessions.values()).find(
-    (s) => s.source && isMultiplexerSource(s.source) &&
+  for (const s of ptySessions.values()) {
+    if (s.source && isMultiplexerSource(s.source) &&
       s.source.kind === source.kind &&
-      s.source.sessionName === source.sessionName,
-  )
+      s.source.sessionName === source.sessionName) {
+      return s
+    }
+  }
+  return undefined
 }
 
 /** 認証済みかつ未アタッチのモバイル picker 接続セット */
@@ -991,25 +1001,14 @@ function spawnSource(source: SessionSource): pty.IPty {
       console.log(`[pty-server] Spawning claude via shell: ${loginShell}${cwd ? ` (cwd: ${cwd})` : ''}`)
       return pty.spawn(loginShell, ['-lc', 'exec claude'], { ...baseOpts, ...(cwd ? { cwd } : {}) })
     }
-    case 'tmux': {
-      assertSafeSessionName(source.sessionName, 'tmux')
-      console.log(`[pty-server] Attaching to tmux session: ${source.sessionName}`)
-      return pty.spawn('tmux', ['attach-session', '-t', source.sessionName], baseOpts)
-    }
-    case 'screen': {
-      assertSafeSessionName(source.sessionName, 'screen')
-      console.log(`[pty-server] Attaching to screen session: ${source.sessionName}`)
-      return pty.spawn('screen', ['-r', source.sessionName], baseOpts)
-    }
-    case 'zellij': {
-      assertSafeSessionName(source.sessionName, 'zellij')
-      console.log(`[pty-server] Attaching to zellij session: ${source.sessionName}`)
-      return pty.spawn('zellij', ['attach', source.sessionName], baseOpts)
-    }
+    case 'tmux':
+    case 'screen':
+    case 'zellij':
     case 'herdr': {
-      assertSafeSessionName(source.sessionName, 'herdr')
-      console.log(`[pty-server] Attaching to herdr session: ${source.sessionName}`)
-      return pty.spawn('herdr', ['session', 'attach', source.sessionName], baseOpts)
+      assertSafeSessionName(source.sessionName, source.kind)
+      console.log(`[pty-server] Attaching to ${source.kind} session: ${source.sessionName}`)
+      const { binary, args } = MUX_SPAWN_CONFIG[source.kind]
+      return pty.spawn(binary, args(source.sessionName), baseOpts)
     }
     case 'shell': {
       const loginShell = resolveShell()
@@ -1017,8 +1016,10 @@ function spawnSource(source: SessionSource): pty.IPty {
       console.log(`[pty-server] Spawning shell: ${loginShell}${cwd ? ` (cwd: ${cwd})` : ''}`)
       return pty.spawn(loginShell, ['-l'], { ...baseOpts, ...(cwd ? { cwd } : {}) })
     }
-    default:
+    default: {
+      const _exhaustive: never = source
       throw new Error(`[pty-server] Unknown session source kind: ${(source as { kind: string }).kind}`)
+    }
   }
 }
 
@@ -1099,6 +1100,12 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
     return results
   }
 
-  const settled = await Promise.allSettled([collectTmux(), collectScreen(), collectZellij(), collectHerdr()])
+  const collectors: Record<MultiplexerKind, () => Promise<MultiplexerSessionInfo[]>> = {
+    tmux: collectTmux,
+    screen: collectScreen,
+    zellij: collectZellij,
+    herdr: collectHerdr,
+  }
+  const settled = await Promise.allSettled(MULTIPLEXER_KINDS.map((k) => collectors[k]()))
   return settled.flatMap((r) => r.status === 'fulfilled' ? r.value : [])
 }

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -170,8 +170,9 @@ const ptySessions = new Map<string, PtySession>()
 
 function findExistingMuxSession(source: MultiplexerSource): PtySession | undefined {
   return Array.from(ptySessions.values()).find(
-    (s) => s.source?.kind === source.kind &&
-      (s.source as MultiplexerSource).sessionName === source.sessionName,
+    (s) => s.source && isMultiplexerSource(s.source) &&
+      s.source.kind === source.kind &&
+      s.source.sessionName === source.sessionName,
   )
 }
 
@@ -1023,7 +1024,7 @@ function spawnSource(source: SessionSource): pty.IPty {
 
 // ─── マルチプレクサセッション一覧取得 ────────────────────────────────────────
 
-/** 利用可能な tmux / screen / zellij / herdr セッション一覧を取得する */
+/** 利用可能なマルチプレクサセッション一覧を取得する */
 export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]> {
   async function collectTmux(): Promise<MultiplexerSessionInfo[]> {
     const results: MultiplexerSessionInfo[] = []

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -167,6 +167,14 @@ interface PtySession {
 
 /** 永続PTYセッションマップ（WS切断後も保持） */
 const ptySessions = new Map<string, PtySession>()
+
+function findExistingMuxSession(source: MultiplexerSource): PtySession | undefined {
+  return Array.from(ptySessions.values()).find(
+    (s) => s.source?.kind === source.kind &&
+      (s.source as MultiplexerSource).sessionName === source.sessionName,
+  )
+}
+
 /** 認証済みかつ未アタッチのモバイル picker 接続セット */
 const pickerSockets = new Set<WebSocket>()
 
@@ -519,12 +527,9 @@ function createExternalSession(providerWs: WebSocket): PtySession {
 export function desktopCreateSession(source: SessionSource = { kind: 'claude' }): string {
   // マルチプレクサの場合、同じセッションにアタッチ済みのPTYセッションがあれば再利用する
   if (isMultiplexerSource(source)) {
-    const { kind, sessionName } = source
-    const existing = Array.from(ptySessions.values()).find(
-      (s) => s.source?.kind === kind && (s.source as typeof source).sessionName === sessionName,
-    )
+    const existing = findExistingMuxSession(source)
     if (existing) {
-      console.log(`[pty-server] Reusing existing PTY session ${existing.id.slice(0, 8)} for ${kind}:${sessionName}`)
+      console.log(`[pty-server] Reusing existing PTY session ${existing.id.slice(0, 8)} for ${source.kind}:${source.sessionName}`)
       return existing.id
     }
   }
@@ -764,11 +769,7 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
         pickerSockets.delete(ws)
         // マルチプレクサは同名セッションが既存なら再利用する（Desktop と同じ挙動）
         const existingMux = isMultiplexer
-          ? Array.from(ptySessions.values()).find(
-              (s) => s.source?.kind === source.kind &&
-                (s.source as MultiplexerSource).sessionName ===
-                (source as MultiplexerSource).sessionName,
-            )
+          ? findExistingMuxSession(source as MultiplexerSource)
           : undefined
         const session = existingMux ?? createPtySession(source, clientIP)
         // 既存セッションを再利用する場合は session_attach と同じ手順で安全にアタッチする

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -4,13 +4,14 @@ import type { IncomingMessage } from 'http'
 import { existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir, hostname as osHostname } from 'os'
-import { WsMessage, SessionInfo, ProjectInfo, MultiplexerSessionInfo, SessionSource, DEFAULT_WS_PORT, MULTIPLEXER_KINDS, isMultiplexerKind, isMultiplexerSource } from '@remocoder/shared'
+import { WsMessage, SessionInfo, ProjectInfo, MultiplexerSessionInfo, SessionSource, MultiplexerSource, DEFAULT_WS_PORT, MULTIPLEXER_KINDS, isMultiplexerKind, isMultiplexerSource } from '@remocoder/shared'
 import { v4 as uuidv4 } from 'uuid'
 import { tryParsePermission, stripAnsi } from './permission-parser'
 import { execAsync, EXEC_ENV } from './exec-env'
 
 let AUTH_TOKEN = process.env.REMOTE_TOKEN ?? uuidv4()
 const SERVER_NAME = osHostname()
+const ALLOWED_SOURCE_KINDS = ['claude', ...MULTIPLEXER_KINDS, 'shell'] as const
 
 // ─── Claude プロジェクト一覧取得 ───────────────────────────────────────────────
 
@@ -749,11 +750,10 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
         detachFromSession()
         // source が指定されていればそれを使用、なければ後方互換で claude として扱う
         const rawSource = msg.source ?? { kind: 'claude', projectPath: msg.projectPath }
-        const allowedKinds = ['claude', ...MULTIPLEXER_KINDS, 'shell'] as const
         const isMultiplexer = isMultiplexerKind(rawSource.kind)
         const rawName = (rawSource as Record<string, unknown>).sessionName
         const isInvalid =
-          !allowedKinds.includes(rawSource.kind as (typeof allowedKinds)[number]) ||
+          !ALLOWED_SOURCE_KINDS.includes(rawSource.kind as (typeof ALLOWED_SOURCE_KINDS)[number]) ||
           (isMultiplexer && (typeof rawName !== 'string' || rawName.length === 0))
         if (isInvalid) {
           console.warn(`[pty-server] Rejected session_create: invalid source ${JSON.stringify(rawSource)}`)
@@ -766,8 +766,8 @@ export function startPtyServer(port = DEFAULT_WS_PORT, callbacks: PtyServerCallb
         const existingMux = isMultiplexer
           ? Array.from(ptySessions.values()).find(
               (s) => s.source?.kind === source.kind &&
-                (s.source as Extract<SessionSource, { sessionName: string }>).sessionName ===
-                (source as Extract<SessionSource, { sessionName: string }>).sessionName,
+                (s.source as MultiplexerSource).sessionName ===
+                (source as MultiplexerSource).sessionName,
             )
           : undefined
         const session = existingMux ?? createPtySession(source, clientIP)

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -27,7 +27,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   /** 新規PTYセッションを作成し、セッションIDを返す */
   ptyCreate: (source?: SessionSource): Promise<string> => ipcRenderer.invoke('pty-create', source),
 
-  /** tmux / screen / zellij のセッション一覧を返す */
+  /** tmux / screen / zellij / herdr のセッション一覧を返す */
   getMultiplexerSessions: (): Promise<MultiplexerSessionInfo[]> =>
     ipcRenderer.invoke('get-multiplexer-sessions'),
 

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -27,7 +27,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   /** 新規PTYセッションを作成し、セッションIDを返す */
   ptyCreate: (source?: SessionSource): Promise<string> => ipcRenderer.invoke('pty-create', source),
 
-  /** tmux / screen / zellij / herdr のセッション一覧を返す */
+  /** マルチプレクサのセッション一覧を返す */
   getMultiplexerSessions: (): Promise<MultiplexerSessionInfo[]> =>
     ipcRenderer.invoke('get-multiplexer-sessions'),
 

--- a/packages/desktop/src/renderer/components/SessionList.tsx
+++ b/packages/desktop/src/renderer/components/SessionList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import type { SessionInfo, MultiplexerSessionInfo } from '@remocoder/shared'
-import { sessionSourceIcon, sessionProjectName, formatSessionElapsed } from '@remocoder/shared'
+import { MULTIPLEXER_KINDS, sessionSourceIcon, sessionProjectName, formatSessionElapsed } from '@remocoder/shared'
 
 interface SessionListProps {
   sessions: SessionInfo[]
@@ -329,7 +329,7 @@ export function SessionList({
           {!hasMux ? (
             <div style={styles.empty}>
               <p style={styles.emptyText}>No sessions</p>
-              <p style={styles.emptySubText}>No tmux / screen / zellij / herdr sessions found</p>
+              <p style={styles.emptySubText}>No {MULTIPLEXER_KINDS.join(' / ')} sessions found</p>
             </div>
           ) : (
             <div style={styles.list}>

--- a/packages/desktop/src/renderer/components/SessionList.tsx
+++ b/packages/desktop/src/renderer/components/SessionList.tsx
@@ -329,7 +329,7 @@ export function SessionList({
           {!hasMux ? (
             <div style={styles.empty}>
               <p style={styles.emptyText}>No sessions</p>
-              <p style={styles.emptySubText}>No tmux / screen / zellij sessions found</p>
+              <p style={styles.emptySubText}>No tmux / screen / zellij / herdr sessions found</p>
             </div>
           ) : (
             <div style={styles.list}>

--- a/packages/mobile/src/assets/terminalHtml.ts
+++ b/packages/mobile/src/assets/terminalHtml.ts
@@ -1,4 +1,4 @@
-import type { SessionSource } from '@remocoder/shared'
+import { MULTIPLEXER_KINDS, type SessionSource } from '@remocoder/shared'
 
 /**
  * @param wsUrl WebSocket URL
@@ -67,8 +67,7 @@ export function buildTerminalHtml(
       function getScrollTarget() {
         const bufType = term.buffer && term.buffer.active && term.buffer.active.type
         const src = currentSource || SESSION_SOURCE
-        const isMultiplexer = src &&
-          (src.kind === 'tmux' || src.kind === 'screen' || src.kind === 'zellij' || src.kind === 'herdr')
+        const isMultiplexer = src && MULTIPLEXER_KINDS.includes(src.kind)
         return { bufType, isMultiplexer }
       }
 
@@ -151,6 +150,7 @@ export function buildTerminalHtml(
     const ATTACH_SESSION_ID = ${sessionIdJs}
     // セッション起動元（null = projectPath を使用）
     const SESSION_SOURCE = ${sourceJs}
+    const MULTIPLEXER_KINDS = ${JSON.stringify(MULTIPLEXER_KINDS)}
 
     // 接続間でセッションIDを維持して再接続時に再アタッチする
     let currentSessionId = ATTACH_SESSION_ID

--- a/packages/mobile/src/assets/terminalHtml.ts
+++ b/packages/mobile/src/assets/terminalHtml.ts
@@ -68,7 +68,7 @@ export function buildTerminalHtml(
         const bufType = term.buffer && term.buffer.active && term.buffer.active.type
         const src = currentSource || SESSION_SOURCE
         const isMultiplexer = src &&
-          (src.kind === 'tmux' || src.kind === 'screen' || src.kind === 'zellij')
+          (src.kind === 'tmux' || src.kind === 'screen' || src.kind === 'zellij' || src.kind === 'herdr')
         return { bufType, isMultiplexer }
       }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,11 +4,12 @@ export type SessionSource =
   | { kind: 'tmux'; sessionName: string }
   | { kind: 'screen'; sessionName: string }
   | { kind: 'zellij'; sessionName: string }
+  | { kind: 'herdr'; sessionName: string }
   | { kind: 'shell'; cwd?: string }
 
-/** tmux / screen / zellij のセッション情報 */
+/** tmux / screen / zellij / herdr のセッション情報 */
 export interface MultiplexerSessionInfo {
-  tool: 'tmux' | 'screen' | 'zellij'
+  tool: 'tmux' | 'screen' | 'zellij' | 'herdr'
   sessionName: string
   /** セッションの追加情報（例: ウィンドウ数、状態） */
   detail?: string
@@ -110,6 +111,7 @@ export function sessionSourceIcon(source?: SessionSource): string {
     case 'tmux':   return '📟'
     case 'screen': return '🖥'
     case 'zellij': return '🪟'
+    case 'herdr':  return '🐑'
     default:       return '🖥'
   }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -8,10 +8,7 @@ export function isMultiplexerKind(kind: string): kind is MultiplexerKind {
 /** PTYセッションの起動元を表す型 */
 export type SessionSource =
   | { kind: 'claude'; projectPath?: string }
-  | { kind: 'tmux'; sessionName: string }
-  | { kind: 'screen'; sessionName: string }
-  | { kind: 'zellij'; sessionName: string }
-  | { kind: 'herdr'; sessionName: string }
+  | { kind: MultiplexerKind; sessionName: string }
   | { kind: 'shell'; cwd?: string }
 
 export type MultiplexerSource = Extract<SessionSource, { sessionName: string }>

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -125,7 +125,10 @@ export function sessionSourceIcon(source?: SessionSource): string {
     case 'screen': return '🖥'
     case 'zellij': return '🪟'
     case 'herdr':  return '🐑'
-    default:       return '🖥'
+    default: {
+      const _exhaustive: never = source
+      return '🖥'
+    }
   }
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,3 +1,10 @@
+export const MULTIPLEXER_KINDS = ['tmux', 'screen', 'zellij', 'herdr'] as const
+export type MultiplexerKind = (typeof MULTIPLEXER_KINDS)[number]
+
+export function isMultiplexerKind(kind: string): kind is MultiplexerKind {
+  return (MULTIPLEXER_KINDS as readonly string[]).includes(kind)
+}
+
 /** PTYセッションの起動元を表す型 */
 export type SessionSource =
   | { kind: 'claude'; projectPath?: string }
@@ -7,9 +14,15 @@ export type SessionSource =
   | { kind: 'herdr'; sessionName: string }
   | { kind: 'shell'; cwd?: string }
 
-/** tmux / screen / zellij / herdr のセッション情報 */
+export type MultiplexerSource = Extract<SessionSource, { sessionName: string }>
+
+export function isMultiplexerSource(source: SessionSource): source is MultiplexerSource {
+  return isMultiplexerKind(source.kind)
+}
+
+/** マルチプレクサのセッション情報 */
 export interface MultiplexerSessionInfo {
-  tool: 'tmux' | 'screen' | 'zellij' | 'herdr'
+  tool: MultiplexerKind
   sessionName: string
   /** セッションの追加情報（例: ウィンドウ数、状態） */
   detail?: string


### PR DESCRIPTION
## Summary

- herdr を tmux / screen / zellij と同じ node-pty 経由のパターンで統合
- `herdr session attach <name>` でセッションにアタッチし、PTY ストリーミングを実現
- `herdr session list --json` でセッション一覧を取得（JSON パースで tmux より簡潔）
- herdr 未インストール環境では従来通り動作（エラーを catch して無視）

## Test plan

- [ ] herdr 未インストール環境でデスクトップ / モバイルが正常動作すること
- [ ] herdr セッションがデスクトップ / モバイルの一覧に表示されること
- [ ] herdr セッションにアタッチして PTY ストリーミングが動作すること
- [ ] 同名セッションへの重複アタッチが既存 PTY セッションを再利用すること
- [ ] TypeScript 型チェック通過済み

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)