### PR TITLE
fix: herdr セッション一覧に作業ディレクトリを表示

### DIFF
--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -1084,27 +1084,30 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
   }
 
   async function collectHerdr(): Promise<MultiplexerSessionInfo[]> {
-    const results: MultiplexerSessionInfo[] = []
-    const { stdout } = await execAsync('herdr session list --json', { env: EXEC_ENV })
-    const parsed = JSON.parse(stdout)
+    const [sessionResult, paneResult] = await Promise.all([
+      execAsync('herdr session list --json', { env: EXEC_ENV }),
+      execAsync('herdr pane list', { env: EXEC_ENV }).catch(() => null),
+    ])
+
+    const parsed = JSON.parse(sessionResult.stdout)
     const sessions: Array<{ name: string; running: boolean; session_dir?: string }> =
       Array.isArray(parsed) ? parsed : parsed.sessions ?? []
 
     let paneCwd: string | undefined
     try {
-      const { stdout: paneOut } = await execAsync('herdr pane list', { env: EXEC_ENV })
-      const paneData = JSON.parse(paneOut)
-      const panes: Array<{ cwd?: string }> = paneData?.result?.panes ?? []
-      paneCwd = panes[0]?.cwd
-    } catch { /* pane list unavailable — skip */ }
+      if (paneResult) {
+        paneCwd = (JSON.parse(paneResult.stdout)?.result?.panes as Array<{ cwd?: string }> | undefined)?.[0]?.cwd
+      }
+    } catch { /* pane list parse failure — proceed without workingDirectory */ }
 
+    const results: MultiplexerSessionInfo[] = []
     for (const s of sessions) {
       if (!s.name || !SAFE_SESSION_NAME_RE.test(s.name)) continue
       results.push({
         tool: 'herdr',
         sessionName: s.name,
         detail: s.running ? 'running' : 'stopped',
-        ...(paneCwd ? { workingDirectory: paneCwd } : {}),
+        workingDirectory: paneCwd,
       })
     }
     return results

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -1100,17 +1100,13 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
       }
     } catch { /* pane list parse failure — proceed without workingDirectory */ }
 
-    const results: MultiplexerSessionInfo[] = []
-    for (const s of sessions) {
-      if (!s.name || !SAFE_SESSION_NAME_RE.test(s.name)) continue
-      results.push({
-        tool: 'herdr',
-        sessionName: s.name,
-        detail: s.running ? 'running' : 'stopped',
-        workingDirectory: paneCwd,
-      })
-    }
-    return results
+    const validSessions = sessions.filter((s) => s.name && SAFE_SESSION_NAME_RE.test(s.name))
+    return validSessions.map((s) => ({
+      tool: 'herdr' as const,
+      sessionName: s.name,
+      detail: s.running ? 'running' : 'stopped',
+      workingDirectory: validSessions.length === 1 ? paneCwd : undefined,
+    }))
   }
 
   const collectors: Record<MultiplexerKind, () => Promise<MultiplexerSessionInfo[]>> = {

--- a/packages/desktop/src/main/pty-server.ts
+++ b/packages/desktop/src/main/pty-server.ts
@@ -1089,12 +1089,22 @@ export async function getMultiplexerSessions(): Promise<MultiplexerSessionInfo[]
     const parsed = JSON.parse(stdout)
     const sessions: Array<{ name: string; running: boolean; session_dir?: string }> =
       Array.isArray(parsed) ? parsed : parsed.sessions ?? []
+
+    let paneCwd: string | undefined
+    try {
+      const { stdout: paneOut } = await execAsync('herdr pane list', { env: EXEC_ENV })
+      const paneData = JSON.parse(paneOut)
+      const panes: Array<{ cwd?: string }> = paneData?.result?.panes ?? []
+      paneCwd = panes[0]?.cwd
+    } catch { /* pane list unavailable — skip */ }
+
     for (const s of sessions) {
       if (!s.name || !SAFE_SESSION_NAME_RE.test(s.name)) continue
       results.push({
         tool: 'herdr',
         sessionName: s.name,
         detail: s.running ? 'running' : 'stopped',
+        ...(paneCwd ? { workingDirectory: paneCwd } : {}),
       })
     }
     return results


### PR DESCRIPTION
## Summary

- `collectHerdr()` で `herdr pane list` を追加で呼び、最初のペインの `cwd` を `workingDirectory` にマッピング
- モバイルアプリ側で herdr セッションのディレクトリパスが表示されるようになる

## Test plan

- [x] ビルド成功
- [x] WebSocket 経由で `multiplexerSessions` に `workingDirectory` が含まれることを確認
- [x] `herdr pane list` 取得失敗時もエラーにならないことを確認（try/catch）

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)